### PR TITLE
🎨 Overhaul Vitessce tutorial notebook

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -114,4 +114,9 @@ docs/*.png
 *.zarr/
 *.h5ad
 *.h5mu
+*.reference.json
+*.offsets.json
+*.ome.tif
+*.ome.tiff
+*.zarr.zip
 test-rxrx/

--- a/docs/vitessce.ipynb
+++ b/docs/vitessce.ipynb
@@ -76,7 +76,6 @@
     "import vitessce as vit\n",
     "from vitessce import data_utils as vitdu\n",
     "from generate_tiff_offsets import get_offsets\n",
-    "import numpy as np\n",
     "import lamindb as ln\n",
     "import zipfile\n",
     "import json\n",

--- a/docs/vitessce.ipynb
+++ b/docs/vitessce.ipynb
@@ -22,40 +22,64 @@
    "source": [
     "This tutorial has been adopted from the data preparation examples in [the Vitessce documention](https://vitessce.github.io/vitessce-python).\n",
     "\n",
-    "It uses a [dataset](https://www.covid19cellatlas.org/index.healthy.html#habib17) from the COVID-19 Cell Atlas."
+    "We demonstrate how to use Vitessce to create interactive visualizations for data stored in LaminDB Artifacts, using multiple data formats."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 4,
    "metadata": {
     "tags": [
      "hide-output"
     ]
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\u001b[93m!\u001b[0m the database (0.76.7) is behind your installed lamindb package (0.77.2)\n",
+      "\u001b[92m→\u001b[0m consider migrating your database: lamin migrate deploy\n",
+      "\u001b[92m→\u001b[0m connected lamindb: vitessce/examples\n"
+     ]
+    }
+   ],
    "source": [
-    "# !pip install vitessce>=0.3.4\n",
-    "# !pip install 'lamindb[jupyter,aws,bionty]'\n",
+    "# !pip install \"vitessce[all]>=3.5.0\"\n",
+    "# !pip install \"generate-tiff-offsets>=0.1.9\"\n",
+    "# !pip install \"lamindb[jupyter,aws,bionty]\"\n",
     "!lamin connect laminlabs/lamin-dev  # <-- replace with your instance"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 8,
    "metadata": {
     "tags": [
      "hide-output"
     ]
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\u001b[92m→\u001b[0m created Transform('XmcumVqv'), started new Run('xt2ErUgo') at 2024-12-04 16:00:56 UTC\n",
+      "\u001b[92m→\u001b[0m notebook imports: anndata==0.10.8 generate-tiff-offsets==0.1.9 lamindb==0.77.2 numpy==1.26.4 vitessce==3.5.0\n"
+     ]
+    }
+   ],
    "source": [
     "from urllib.request import urlretrieve\n",
     "from pathlib import Path\n",
     "from anndata import read_h5ad\n",
     "import vitessce as vit\n",
     "from vitessce import data_utils as vitdu\n",
+    "from generate_tiff_offsets import get_offsets\n",
+    "import numpy as np\n",
     "import lamindb as ln\n",
+    "import zipfile\n",
+    "import json\n",
     "\n",
     "# [optional] track the current notebook or script\n",
     "ln.track(\"BZhZQ6uIbkWv0000\")"
@@ -65,78 +89,187 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Save your dataset"
+    "## Visualize an AnnData object (H5AD format)"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Convert the dataset to `.zarr` format."
+    "Here, we download an example H5AD file (approximately 22 MB). This is a [dataset](https://www.covid19cellatlas.org/index.healthy.html#habib17) from the COVID-19 Cell Atlas."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "tags": [
-     "hide-output"
-    ]
-   },
+   "execution_count": 9,
+   "metadata": {},
    "outputs": [],
    "source": [
-    "# from https://github.com/vitessce/vitessce-python/blob/main/demos/habib-2017/src/convert_to_zarr.py\n",
-    "def convert_h5ad_to_zarr(input_path, output_path):\n",
-    "    adata = read_h5ad(input_path)\n",
-    "    adata = adata[:, adata.var[\"highly_variable\"]].copy()\n",
-    "    leaf_list = vitdu.sort_var_axis(adata.X, adata.var.index.values)\n",
-    "    adata = adata[:, leaf_list].copy()\n",
-    "    adata.layers[\"X_uint8\"] = vitdu.to_uint8(adata.X, norm_along=\"var\")\n",
-    "    adata = vitdu.optimize_adata(\n",
-    "        adata, obs_cols=[\"CellType\"], obsm_keys=[\"X_umap\"], layer_keys=[\"X_uint8\"]\n",
-    "    )\n",
-    "    adata.write_zarr(output_path)\n",
-    "\n",
-    "\n",
-    "h5ad_filepath = \"./habib17.processed.h5ad\"\n",
-    "if not Path(h5ad_filepath).exists():\n",
+    "h5ad_raw_filepath = \"./habib17.raw.h5ad\"\n",
+    "h5ad_processed_filepath = \"./habib17.processed.h5ad\"\n",
+    "if not Path(h5ad_raw_filepath).exists():\n",
     "    urlretrieve(\n",
-    "        \"https://covid19.cog.sanger.ac.uk/habib17.processed.h5ad\", h5ad_filepath\n",
-    "    )\n",
-    "zarr_filepath = \"./hhabib_2017_nature_methods.anndata.zarr\"\n",
-    "convert_h5ad_to_zarr(h5ad_filepath, zarr_filepath)"
+    "        \"https://covid19.cog.sanger.ac.uk/habib17.processed.h5ad\", h5ad_raw_filepath\n",
+    "    )"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Save a `.zarr` version of the dataset to lamindb."
+    "This AnnData file was not saved recently and `read_h5ad` will warn us about this. By reading and subsequently re-writing the file using an up-to-date `anndata` package version, we ensure that the dataset is saved using the latest AnnData H5AD format."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "tags": [
-     "hide-output"
-    ]
-   },
+   "execution_count": 10,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/Users/markkeller/research/dbmi/vitessce/lamin/hello-world/.venv/lib/python3.10/site-packages/anndata/compat/__init__.py:311: FutureWarning: Moving element from .uns['neighbors']['distances'] to .obsp['distances'].\n",
+      "\n",
+      "This is where adjacency matrices should go now.\n",
+      "  warn(\n",
+      "/Users/markkeller/research/dbmi/vitessce/lamin/hello-world/.venv/lib/python3.10/site-packages/anndata/compat/__init__.py:311: FutureWarning: Moving element from .uns['neighbors']['connectivities'] to .obsp['connectivities'].\n",
+      "\n",
+      "This is where adjacency matrices should go now.\n",
+      "  warn(\n"
+     ]
+    }
+   ],
+   "source": [
+    "adata = read_h5ad(h5ad_raw_filepath)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Optionally, we can modify the AnnData object, for example to subset it to the highly variable genes (which will affect the amount of data that is displayed in the heatmap visualization)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "metadata": {},
    "outputs": [],
    "source": [
-    "zarr_artifact = ln.Artifact(\n",
-    "    zarr_filepath,\n",
-    "    description=\"Habib et al., 2017 Nature Methods, optimized anndata zarr\",\n",
+    "adata = adata[:, adata.var[\"highly_variable\"]].copy()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "adata.write_h5ad(h5ad_processed_filepath)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Save the dataset"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Save the `.h5ad` file as a LaminDB Artifact."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "metadata": {
+    "scrolled": true
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\u001b[92m→\u001b[0m returning existing artifact with same hash: Artifact(uid='1g3a41z0hggWNBrk0000', is_latest=True, key='vitessce_examples/habib17.h5ad', description='Habib et al., 2017 Nature Methods, h5ad', suffix='.h5ad', type='dataset', size=22586523, hash='-O1gvNOMqXm96TNFJ4yZXQ', _hash_type='md5', _accessor='AnnData', visibility=1, _key_is_virtual=True, storage_id=1, transform_id=16, run_id=73, created_by_id=2, created_at=2024-12-03 21:31:03 UTC)\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "Artifact(uid='1g3a41z0hggWNBrk0000', is_latest=True, key='vitessce_examples/habib17.h5ad', description='Habib et al., 2017 Nature Methods, h5ad', suffix='.h5ad', type='dataset', size=22586523, hash='-O1gvNOMqXm96TNFJ4yZXQ', _hash_type='md5', _accessor='AnnData', visibility=1, _key_is_virtual=True, storage_id=1, transform_id=17, run_id=79, created_by_id=2, created_at=2024-12-03 21:31:03 UTC)"
+      ]
+     },
+     "execution_count": 13,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "h5ad_artifact = ln.Artifact(\n",
+    "    h5ad_processed_filepath,\n",
+    "    key=\"vitessce_examples/habib17.h5ad\",\n",
+    "    description=\"Habib et al., 2017 Nature Methods, h5ad\",\n",
     "    type=\"dataset\",\n",
     ")\n",
-    "zarr_artifact.save()"
+    "h5ad_artifact.save()"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Save a VitessceConfig object"
+    "When using `.h5ad` files, we construct a [Reference Specification](https://fsspec.github.io/kerchunk/spec.html) which enables interoperability with the [Zarr](https://zarrita.dev/packages/storage.html#referencestore) interface."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 14,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "ref_spec = vitdu.generate_h5ad_ref_spec(h5ad_processed_filepath)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We next need to save the corresponding Reference Specification to a JSON file and upload it to LaminDB as an Artifact."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 15,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\u001b[92m→\u001b[0m returning existing artifact with same hash: Artifact(uid='O7CTVi6XjnfsceQ20000', is_latest=True, key='vitessce_examples/habib17.reference.json', description='Reference JSON for H5AD file, Habib et al., 2017 Nature Methods', suffix='.json', size=543575, hash='XFOV2X6Bw6_zTugTOEBehg', _hash_type='md5', visibility=1, _key_is_virtual=True, storage_id=1, transform_id=16, run_id=73, created_by_id=2, created_at=2024-12-03 21:31:14 UTC)\n"
+     ]
+    }
+   ],
+   "source": [
+    "ref_path = \"./habib17.processed.reference.json\"\n",
+    "with open(ref_path, \"w\") as file:\n",
+    "    json.dump(ref_spec, file)\n",
+    "ref_artifact = ln.Artifact(\n",
+    "    ref_path,\n",
+    "    key=\"vitessce_examples/habib17.reference.json\",\n",
+    "    description=\"Reference JSON for H5AD file, Habib et al., 2017 Nature Methods\"\n",
+    ").save()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Save a VitessceConfig object"
    ]
   },
   {
@@ -147,35 +280,40 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "You can pass LaminDB Artifacts to the AnnDataWrapper class using the `adata_artifact` and `ref_artifact` [parameters](https://python-docs.vitessce.io/api_data.html#vitessce.wrappers.AnnDataWrapper)."
+   ]
+  },
+  {
    "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "tags": [
-     "hide-output"
-    ]
-   },
+   "execution_count": 16,
+   "metadata": {},
    "outputs": [],
    "source": [
     "vc = vit.VitessceConfig(\n",
-    "    schema_version=\"1.0.15\",\n",
-    "    description=zarr_artifact.description,\n",
+    "    schema_version=\"1.0.17\",\n",
+    "    description=h5ad_artifact.description,\n",
     ")\n",
     "dataset = vc.add_dataset(name=\"Habib 2017\").add_object(\n",
     "    vit.AnnDataWrapper(\n",
-    "        adata_artifact=zarr_artifact,\n",
-    "        obs_feature_matrix_path=\"layers/X_uint8\",\n",
+    "        adata_artifact=h5ad_artifact,\n",
+    "        ref_artifact=ref_artifact,\n",
+    "        obs_feature_matrix_path=\"X\",\n",
     "        obs_embedding_paths=[\"obsm/X_umap\"],\n",
     "        obs_embedding_names=[\"UMAP\"],\n",
     "        obs_set_paths=[\"obs/CellType\"],\n",
     "        obs_set_names=[\"Cell Type\"],\n",
     "    )\n",
     ")\n",
-    "obs_sets = vc.add_view(vit.Component.OBS_SETS, dataset=dataset)\n",
-    "obs_sets_sizes = vc.add_view(vit.Component.OBS_SET_SIZES, dataset=dataset)\n",
-    "scatterplot = vc.add_view(vit.Component.SCATTERPLOT, dataset=dataset, mapping=\"UMAP\")\n",
-    "heatmap = vc.add_view(vit.Component.HEATMAP, dataset=dataset)\n",
-    "genes = vc.add_view(vit.Component.FEATURE_LIST, dataset=dataset)\n",
-    "vc.layout(((scatterplot | obs_sets) / heatmap) | (obs_sets_sizes / genes))"
+    "obs_sets = vc.add_view(vit.ViewType.OBS_SETS, dataset=dataset)\n",
+    "obs_sets_sizes = vc.add_view(vit.ViewType.OBS_SET_SIZES, dataset=dataset)\n",
+    "scatterplot = vc.add_view(vit.ViewType.SCATTERPLOT, dataset=dataset, mapping=\"UMAP\")\n",
+    "heatmap = vc.add_view(vit.ViewType.HEATMAP, dataset=dataset)\n",
+    "genes = vc.add_view(vit.ViewType.FEATURE_LIST, dataset=dataset)\n",
+    "vc.link_views([scatterplot, heatmap], [\"featureValueColormapRange\"], [[0.0, 0.1]])\n",
+    "vc.layout(((scatterplot | obs_sets) / heatmap) | (obs_sets_sizes / genes));"
    ]
   },
   {
@@ -187,17 +325,148 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 17,
    "metadata": {
     "tags": [
      "hide-output"
     ]
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\u001b[92m→\u001b[0m VitessceConfig references these artifacts:\n",
+      "Artifact(uid='1g3a41z0hggWNBrk0000', is_latest=True, key='vitessce_examples/habib17.h5ad', description='Habib et al., 2017 Nature Methods, h5ad', suffix='.h5ad', type='dataset', size=22586523, hash='-O1gvNOMqXm96TNFJ4yZXQ', _hash_type='md5', _accessor='AnnData', visibility=1, _key_is_virtual=True, storage_id=1, transform_id=17, run_id=79, created_by_id=2, created_at=2024-12-03 21:31:03 UTC)\n",
+      "Artifact(uid='O7CTVi6XjnfsceQ20000', is_latest=True, key='vitessce_examples/habib17.reference.json', description='Reference JSON for H5AD file, Habib et al., 2017 Nature Methods', suffix='.json', size=543575, hash='XFOV2X6Bw6_zTugTOEBehg', _hash_type='md5', visibility=1, _key_is_virtual=True, storage_id=1, transform_id=17, run_id=79, created_by_id=2, created_at=2024-12-03 21:31:14 UTC)\n",
+      "\u001b[93m!\u001b[0m returning existing collection with same hash: Collection(uid='obXokdzOnSH2tytJ0000', is_latest=True, name='View Habib17 (h5ad) in Vitessce', hash='U9WUAN_l9mLUWYqO2pJ9-g', visibility=1, created_by_id=2, transform_id=16, run_id=73, created_at=2024-12-03 21:33:48 UTC)\n",
+      "\u001b[92m→\u001b[0m returning existing artifact with same hash: Artifact(uid='ffUKrGJGNHL3TDhG0000', is_latest=True, description='View Habib17 (h5ad) in Vitessce', suffix='.vitessce.json', size=1365, hash='84eEO5D0fofN-0Sx47tCSA', _hash_type='md5', visibility=1, _key_is_virtual=True, storage_id=1, transform_id=15, run_id=74, created_by_id=2, created_at=2024-12-04 12:59:42 UTC)\n",
+      "\u001b[92m→\u001b[0m VitessceConfig: https://lamin.ai/vitessce/examples/artifact/ffUKrGJGNHL3TDhG0000\n",
+      "\u001b[92m→\u001b[0m Collection: https://lamin.ai/vitessce/examples/collection/obXokdzOnSH2tytJ0000\n"
+     ]
+    }
+   ],
    "source": [
-    "vc_artifact = ln.integrations.save_vitessce_config(\n",
-    "    vc, description=\"View Habib17 in Vitessce\"\n",
+    "h5ad_vc_artifact = ln.integrations.save_vitessce_config(\n",
+    "    vc, description=\"View Habib17 (h5ad) in Vitessce\",\n",
     ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 18,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "image/svg+xml": [
+       "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"no\"?>\n",
+       "<!DOCTYPE svg PUBLIC \"-//W3C//DTD SVG 1.1//EN\"\n",
+       " \"http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd\">\n",
+       "<!-- Generated by graphviz version 2.40.1 (20161225.0304)\n",
+       " -->\n",
+       "<!-- Title: artifact_ffUKrGJGNHL3TDhG0000 Pages: 1 -->\n",
+       "<svg width=\"756pt\" height=\"288pt\"\n",
+       " viewBox=\"0.00 0.00 755.92 288.00\" xmlns=\"http://www.w3.org/2000/svg\" xmlns:xlink=\"http://www.w3.org/1999/xlink\">\n",
+       "<g id=\"graph0\" class=\"graph\" transform=\"scale(1 1) rotate(0) translate(4 284)\">\n",
+       "<title>artifact_ffUKrGJGNHL3TDhG0000</title>\n",
+       "<polygon fill=\"#ffffff\" stroke=\"transparent\" points=\"-4,4 -4,-284 751.9219,-284 751.9219,4 -4,4\"/>\n",
+       "<!-- artifact_1g3a41z0hggWNBrk0000 -->\n",
+       "<g id=\"node1\" class=\"node\">\n",
+       "<title>artifact_1g3a41z0hggWNBrk0000</title>\n",
+       "<path fill=\"#f0fff0\" stroke=\"#065f46\" d=\"M199.8433,-196C199.8433,-196 12.0522,-196 12.0522,-196 6.0522,-196 .0522,-190 .0522,-184 .0522,-184 .0522,-170 .0522,-170 .0522,-164 6.0522,-158 12.0522,-158 12.0522,-158 199.8433,-158 199.8433,-158 205.8433,-158 211.8433,-164 211.8433,-170 211.8433,-170 211.8433,-184 211.8433,-184 211.8433,-190 205.8433,-196 199.8433,-196\"/>\n",
+       "<text text-anchor=\"start\" x=\"8\" y=\"-185\" font-family=\"Helvetica,sans-Serif\" font-size=\"10.00\" fill=\"#000000\">📄 Habib et al., 2017 Nature Methods, h5ad</text>\n",
+       "<text text-anchor=\"start\" x=\"39.0947\" y=\"-175\" font-family=\"Monospace\" font-size=\"10.00\" fill=\"#c0c0c0\">uid=1g3a41z0hggWNBrk0000</text>\n",
+       "<text text-anchor=\"start\" x=\"78.8457\" y=\"-165\" font-family=\"Monospace\" font-size=\"10.00\" fill=\"#c0c0c0\">suffix=.h5ad</text>\n",
+       "</g>\n",
+       "<!-- run_CCFZLC4nNEr748iKG5Kz -->\n",
+       "<g id=\"node2\" class=\"node\">\n",
+       "<title>run_CCFZLC4nNEr748iKG5Kz</title>\n",
+       "<path fill=\"#dcdcdc\" stroke=\"#065f46\" d=\"M313.428,-122C313.428,-122 184.4675,-122 184.4675,-122 178.4675,-122 172.4675,-116 172.4675,-110 172.4675,-110 172.4675,-86 172.4675,-86 172.4675,-80 178.4675,-74 184.4675,-74 184.4675,-74 313.428,-74 313.428,-74 319.428,-74 325.428,-80 325.428,-86 325.428,-86 325.428,-110 325.428,-110 325.428,-116 319.428,-122 313.428,-122\"/>\n",
+       "<text text-anchor=\"start\" x=\"193.5317\" y=\"-111\" font-family=\"Helvetica,sans-Serif\" font-size=\"10.00\" fill=\"#000000\">🔧 save_vitessce_config</text>\n",
+       "<text text-anchor=\"start\" x=\"194.9731\" y=\"-101\" font-family=\"Monospace\" font-size=\"10.00\" fill=\"#c0c0c0\">uid=kup03MJBsIVa0002</text>\n",
+       "<text text-anchor=\"start\" x=\"184.7461\" y=\"-91\" font-family=\"Monospace\" font-size=\"10.00\" fill=\"#c0c0c0\">type=function, user=mkeller7</text>\n",
+       "<text text-anchor=\"start\" x=\"180.708\" y=\"-81\" font-family=\"Monospace\" font-size=\"10.00\" fill=\"#c0c0c0\">run=2024&#45;12&#45;04 16:01:05 UTC</text>\n",
+       "</g>\n",
+       "<!-- artifact_1g3a41z0hggWNBrk0000&#45;&gt;run_CCFZLC4nNEr748iKG5Kz -->\n",
+       "<g id=\"edge1\" class=\"edge\">\n",
+       "<title>artifact_1g3a41z0hggWNBrk0000&#45;&gt;run_CCFZLC4nNEr748iKG5Kz</title>\n",
+       "<path fill=\"none\" stroke=\"#696969\" d=\"M140.5641,-157.8763C158.6999,-147.8572 181.1955,-135.4296 200.9839,-124.4975\"/>\n",
+       "<polygon fill=\"#696969\" stroke=\"#696969\" points=\"201.8938,-125.9942 205.4241,-122.0445 200.2013,-122.9306 201.8938,-125.9942\"/>\n",
+       "</g>\n",
+       "<!-- artifact_ffUKrGJGNHL3TDhG0000 -->\n",
+       "<g id=\"node4\" class=\"node\">\n",
+       "<title>artifact_ffUKrGJGNHL3TDhG0000</title>\n",
+       "<path fill=\"#10b981\" stroke=\"#065f46\" d=\"M324.896,-38C324.896,-38 172.9995,-38 172.9995,-38 166.9995,-38 160.9995,-32 160.9995,-26 160.9995,-26 160.9995,-12 160.9995,-12 160.9995,-6 166.9995,0 172.9995,0 172.9995,0 324.896,0 324.896,0 330.896,0 336.896,-6 336.896,-12 336.896,-12 336.896,-26 336.896,-26 336.896,-32 330.896,-38 324.896,-38\"/>\n",
+       "<text text-anchor=\"start\" x=\"168.9736\" y=\"-27\" font-family=\"Helvetica,sans-Serif\" font-size=\"10.00\" fill=\"#000000\">📄 View Habib17 (h5ad) in Vitessce</text>\n",
+       "<text text-anchor=\"start\" x=\"180.5347\" y=\"-17\" font-family=\"Monospace\" font-size=\"10.00\" fill=\"#c0c0c0\">uid=ffUKrGJGNHL3TDhG0000</text>\n",
+       "<text text-anchor=\"start\" x=\"204.3457\" y=\"-7\" font-family=\"Monospace\" font-size=\"10.00\" fill=\"#c0c0c0\">suffix=.vitessce.json</text>\n",
+       "</g>\n",
+       "<!-- run_CCFZLC4nNEr748iKG5Kz&#45;&gt;artifact_ffUKrGJGNHL3TDhG0000 -->\n",
+       "<g id=\"edge3\" class=\"edge\">\n",
+       "<title>run_CCFZLC4nNEr748iKG5Kz&#45;&gt;artifact_ffUKrGJGNHL3TDhG0000</title>\n",
+       "<path fill=\"none\" stroke=\"#696969\" d=\"M248.9478,-73.8681C248.9478,-64.2201 248.9478,-53.1228 248.9478,-43.4439\"/>\n",
+       "<polygon fill=\"#696969\" stroke=\"#696969\" points=\"250.6978,-43.2308 248.9478,-38.2309 247.1978,-43.2309 250.6978,-43.2308\"/>\n",
+       "</g>\n",
+       "<!-- artifact_O7CTVi6XjnfsceQ20000 -->\n",
+       "<g id=\"node3\" class=\"node\">\n",
+       "<title>artifact_O7CTVi6XjnfsceQ20000</title>\n",
+       "<path fill=\"#f0fff0\" stroke=\"#065f46\" d=\"M542.1461,-196C542.1461,-196 241.7494,-196 241.7494,-196 235.7494,-196 229.7494,-190 229.7494,-184 229.7494,-184 229.7494,-170 229.7494,-170 229.7494,-164 235.7494,-158 241.7494,-158 241.7494,-158 542.1461,-158 542.1461,-158 548.1461,-158 554.1461,-164 554.1461,-170 554.1461,-170 554.1461,-184 554.1461,-184 554.1461,-190 548.1461,-196 542.1461,-196\"/>\n",
+       "<text text-anchor=\"start\" x=\"237.5986\" y=\"-185\" font-family=\"Helvetica,sans-Serif\" font-size=\"10.00\" fill=\"#000000\">📄 Reference JSON for H5AD file, Habib et al., 2017 Nature Methods</text>\n",
+       "<text text-anchor=\"start\" x=\"327.6924\" y=\"-175\" font-family=\"Monospace\" font-size=\"10.00\" fill=\"#c0c0c0\">uid=O7CTVi6XjnfsceQ20000</text>\n",
+       "<text text-anchor=\"start\" x=\"366.7964\" y=\"-165\" font-family=\"Monospace\" font-size=\"10.00\" fill=\"#c0c0c0\">suffix=.json</text>\n",
+       "</g>\n",
+       "<!-- artifact_O7CTVi6XjnfsceQ20000&#45;&gt;run_CCFZLC4nNEr748iKG5Kz -->\n",
+       "<g id=\"edge2\" class=\"edge\">\n",
+       "<title>artifact_O7CTVi6XjnfsceQ20000&#45;&gt;run_CCFZLC4nNEr748iKG5Kz</title>\n",
+       "<path fill=\"none\" stroke=\"#696969\" d=\"M357.3314,-157.8763C339.1956,-147.8572 316.7,-135.4296 296.9117,-124.4975\"/>\n",
+       "<polygon fill=\"#696969\" stroke=\"#696969\" points=\"297.6942,-122.9306 292.4714,-122.0445 296.0017,-125.9942 297.6942,-122.9306\"/>\n",
+       "</g>\n",
+       "<!-- run_xt2ErUgo7KKqUOOAnVad -->\n",
+       "<g id=\"node5\" class=\"node\">\n",
+       "<title>run_xt2ErUgo7KKqUOOAnVad</title>\n",
+       "<path fill=\"#dcdcdc\" stroke=\"#065f46\" d=\"M456.428,-280C456.428,-280 327.4675,-280 327.4675,-280 321.4675,-280 315.4675,-274 315.4675,-268 315.4675,-268 315.4675,-244 315.4675,-244 315.4675,-238 321.4675,-232 327.4675,-232 327.4675,-232 456.428,-232 456.428,-232 462.428,-232 468.428,-238 468.428,-244 468.428,-244 468.428,-268 468.428,-268 468.428,-274 462.428,-280 456.428,-280\"/>\n",
+       "<text text-anchor=\"start\" x=\"365.25\" y=\"-269\" font-family=\"Helvetica,sans-Serif\" font-size=\"10.00\" fill=\"#000000\">📔 Vitessce</text>\n",
+       "<text text-anchor=\"start\" x=\"333.7202\" y=\"-259\" font-family=\"Monospace\" font-size=\"10.00\" fill=\"#c0c0c0\">uid=XmcumVqvKZd30002</text>\n",
+       "<text text-anchor=\"start\" x=\"324.6846\" y=\"-249\" font-family=\"Monospace\" font-size=\"10.00\" fill=\"#c0c0c0\">type=notebook, user=mkeller7</text>\n",
+       "<text text-anchor=\"start\" x=\"323.708\" y=\"-239\" font-family=\"Monospace\" font-size=\"10.00\" fill=\"#c0c0c0\">run=2024&#45;12&#45;04 16:00:56 UTC</text>\n",
+       "</g>\n",
+       "<!-- run_xt2ErUgo7KKqUOOAnVad&#45;&gt;artifact_1g3a41z0hggWNBrk0000 -->\n",
+       "<g id=\"edge4\" class=\"edge\">\n",
+       "<title>run_xt2ErUgo7KKqUOOAnVad&#45;&gt;artifact_1g3a41z0hggWNBrk0000</title>\n",
+       "<path fill=\"none\" stroke=\"#696969\" d=\"M315.6807,-234.9332C273.7017,-223.3376 221.8323,-209.0101 180.1795,-197.5046\"/>\n",
+       "<polygon fill=\"#696969\" stroke=\"#696969\" points=\"180.4374,-195.7603 175.1519,-196.1158 179.5054,-199.134 180.4374,-195.7603\"/>\n",
+       "</g>\n",
+       "<!-- run_xt2ErUgo7KKqUOOAnVad&#45;&gt;artifact_O7CTVi6XjnfsceQ20000 -->\n",
+       "<g id=\"edge5\" class=\"edge\">\n",
+       "<title>run_xt2ErUgo7KKqUOOAnVad&#45;&gt;artifact_O7CTVi6XjnfsceQ20000</title>\n",
+       "<path fill=\"none\" stroke=\"#696969\" d=\"M391.9478,-231.8681C391.9478,-222.2201 391.9478,-211.1228 391.9478,-201.4439\"/>\n",
+       "<polygon fill=\"#696969\" stroke=\"#696969\" points=\"393.6978,-201.2308 391.9478,-196.2309 390.1978,-201.2309 393.6978,-201.2308\"/>\n",
+       "</g>\n",
+       "<!-- collection_obXokdzOnSH2tytJ0000 -->\n",
+       "<g id=\"node6\" class=\"node\">\n",
+       "<title>collection_obXokdzOnSH2tytJ0000</title>\n",
+       "<path fill=\"#f0fff0\" stroke=\"#065f46\" d=\"M735.896,-196C735.896,-196 583.9995,-196 583.9995,-196 577.9995,-196 571.9995,-190 571.9995,-184 571.9995,-184 571.9995,-170 571.9995,-170 571.9995,-164 577.9995,-158 583.9995,-158 583.9995,-158 735.896,-158 735.896,-158 741.896,-158 747.896,-164 747.896,-170 747.896,-170 747.896,-184 747.896,-184 747.896,-190 741.896,-196 735.896,-196\"/>\n",
+       "<text text-anchor=\"start\" x=\"579.9736\" y=\"-185\" font-family=\"Helvetica,sans-Serif\" font-size=\"10.00\" fill=\"#000000\">🍱 View Habib17 (h5ad) in Vitessce</text>\n",
+       "<text text-anchor=\"start\" x=\"595.5996\" y=\"-175\" font-family=\"Monospace\" font-size=\"10.00\" fill=\"#c0c0c0\">uid=obXokdzOnSH2tytJ0000</text>\n",
+       "<text text-anchor=\"start\" x=\"628.9565\" y=\"-165\" font-family=\"Monospace\" font-size=\"10.00\" fill=\"#c0c0c0\">version=None</text>\n",
+       "</g>\n",
+       "<!-- run_xt2ErUgo7KKqUOOAnVad&#45;&gt;collection_obXokdzOnSH2tytJ0000 -->\n",
+       "<g id=\"edge6\" class=\"edge\">\n",
+       "<title>run_xt2ErUgo7KKqUOOAnVad&#45;&gt;collection_obXokdzOnSH2tytJ0000</title>\n",
+       "<path fill=\"none\" stroke=\"#696969\" d=\"M468.3871,-233.4675C506.7362,-222.1631 552.851,-208.5696 590.2243,-197.5528\"/>\n",
+       "<polygon fill=\"#696969\" stroke=\"#696969\" points=\"590.9028,-199.1773 595.2039,-196.0849 589.9131,-195.8201 590.9028,-199.1773\"/>\n",
+       "</g>\n",
+       "</g>\n",
+       "</svg>\n"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "h5ad_vc_artifact.view_lineage()"
    ]
   },
   {
@@ -206,30 +475,1472 @@
    "source": [
     ":::{note}\n",
     "\n",
-    "You can now see the Vitessce button show up on your dataset as in this [example dataset](https://lamin.ai/laminlabs/lamindata/artifact/HXJ4DDAw8012jVKwoxgd).\n",
+    "After running `save_vitessce_config`, a Vitessce button will appear next to the dataset in the [Artifacts](https://lamin.ai/vitessce/examples/artifacts) page of the web interface.\n",
     "\n",
-    "If your `VitessceConfig` object contains multiple datasets, the Vitessce button will appear next to a `Collection` that groups these artifacts.\n",
+    "If your `VitessceConfig` object references data from multiple artifacts, the Vitessce button will appear next to a `Collection` that groups these artifacts (on the [Collections](https://lamin.ai/vitessce/examples/collections) tab of the Artifacts page).\n",
+    "Note that when using an `.h5ad`-based Artifact, the presence of the corresponding `.reference.json` file will result in the creation of a Collection.\n",
+    "\n",
+    ":::"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Visualize an AnnData object (Zarr format)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "AnnData objects can be saved on-disk to not only `.h5ad` files, but also to [Zarr stores](https://zarr.readthedocs.io/en/stable/tutorial.html#storage-alternatives) using AnnData's [write_zarr](https://anndata.readthedocs.io/en/latest/generated/anndata.AnnData.write_zarr.html) method."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Save the dataset"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Convert the dataset to `.zarr` format. Often, Zarr data is stored on-disk using a [DirectoryStore](https://zarr.readthedocs.io/en/stable/api/storage.html#zarr.storage.DirectoryStore). By convention, these directories are named using a `.zarr` suffix."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 19,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "zarr_processed_filepath = \"./habib17.anndata.zarr\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 20,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/Users/markkeller/research/dbmi/vitessce/lamin/hello-world/.venv/lib/python3.10/site-packages/anndata/compat/__init__.py:311: FutureWarning: Moving element from .uns['neighbors']['distances'] to .obsp['distances'].\n",
+      "\n",
+      "This is where adjacency matrices should go now.\n",
+      "  warn(\n",
+      "/Users/markkeller/research/dbmi/vitessce/lamin/hello-world/.venv/lib/python3.10/site-packages/anndata/compat/__init__.py:311: FutureWarning: Moving element from .uns['neighbors']['connectivities'] to .obsp['connectivities'].\n",
+      "\n",
+      "This is where adjacency matrices should go now.\n",
+      "  warn(\n"
+     ]
+    }
+   ],
+   "source": [
+    "adata = read_h5ad(h5ad_raw_filepath)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Just like in the above section, we may want to modify the AnnData object prior to saving it as a LaminDB Artifact that we will use for visualization."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 21,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "adata = adata[:, adata.var[\"highly_variable\"]].copy()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Note the usage of `.write_zarr` below, as opposed to `.write_h5ad`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 22,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "adata.write_zarr(zarr_processed_filepath)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Save the `.zarr` directory as a LaminDB Artifact."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 24,
+   "metadata": {
+    "scrolled": true
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\u001b[92m→\u001b[0m returning existing artifact with same hash: Artifact(uid='kWwG45Hr26KZUW3g0004', is_latest=True, key='vitessce_examples/habib17.adata.zarr', description='Habib et al., 2017 Nature Methods, zarr', suffix='.anndata.zarr', type='dataset', size=10601062, hash='Ap_EL5yPdfyD07Xjpe1SlA', n_objects=208, _hash_type='md5-d', _accessor='AnnData', visibility=1, _key_is_virtual=True, storage_id=1, transform_id=17, run_id=79, created_by_id=2, created_at=2024-12-04 16:01:11 UTC)\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "Artifact(uid='kWwG45Hr26KZUW3g0004', is_latest=True, key='vitessce_examples/habib17.adata.zarr', description='Habib et al., 2017 Nature Methods, zarr', suffix='.anndata.zarr', type='dataset', size=10601062, hash='Ap_EL5yPdfyD07Xjpe1SlA', n_objects=208, _hash_type='md5-d', _accessor='AnnData', visibility=1, _key_is_virtual=True, storage_id=1, transform_id=17, run_id=79, created_by_id=2, created_at=2024-12-04 16:01:11 UTC)"
+      ]
+     },
+     "execution_count": 24,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "adata_zarr_artifact = ln.Artifact(\n",
+    "    zarr_processed_filepath,\n",
+    "    key=\"vitessce_examples/habib17.adata.zarr\",\n",
+    "    description=\"Habib et al., 2017 Nature Methods, zarr\",\n",
+    "    type=\"dataset\",\n",
+    ")\n",
+    "adata_zarr_artifact.save()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Save a VitessceConfig object"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "You can create a dashboard for one or several datasets by using Vitessce's component API.\n",
+    "Here, we configure the visualization the same way as above in the `.h5ad`-based example, with the exception of the `ref_artifact` parameter, as `.zarr`-based AnnData objects do not require a Reference Specification for Zarr interoperability."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 25,
+   "metadata": {
+    "tags": [
+     "hide-output"
+    ]
+   },
+   "outputs": [],
+   "source": [
+    "vc = vit.VitessceConfig(\n",
+    "    schema_version=\"1.0.17\",\n",
+    "    description=adata_zarr_artifact.description,\n",
+    ")\n",
+    "dataset = vc.add_dataset(name=\"Habib 2017\").add_object(\n",
+    "    vit.AnnDataWrapper(\n",
+    "        adata_artifact=adata_zarr_artifact,\n",
+    "        obs_feature_matrix_path=\"X\",\n",
+    "        obs_embedding_paths=[\"obsm/X_umap\"],\n",
+    "        obs_embedding_names=[\"UMAP\"],\n",
+    "        obs_set_paths=[\"obs/CellType\"],\n",
+    "        obs_set_names=[\"Cell Type\"],\n",
+    "    )\n",
+    ")\n",
+    "obs_sets = vc.add_view(vit.Component.OBS_SETS, dataset=dataset)\n",
+    "obs_sets_sizes = vc.add_view(vit.Component.OBS_SET_SIZES, dataset=dataset)\n",
+    "scatterplot = vc.add_view(vit.Component.SCATTERPLOT, dataset=dataset, mapping=\"UMAP\")\n",
+    "heatmap = vc.add_view(vit.Component.HEATMAP, dataset=dataset)\n",
+    "genes = vc.add_view(vit.Component.FEATURE_LIST, dataset=dataset)\n",
+    "vc.link_views([scatterplot, heatmap], [\"featureValueColormapRange\"], [[0.0, 0.1]])\n",
+    "vc.layout(((scatterplot | obs_sets) / heatmap) | (obs_sets_sizes / genes));"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Save the `VitessceConfig` object."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 26,
+   "metadata": {
+    "tags": [
+     "hide-output"
+    ]
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\u001b[92m→\u001b[0m VitessceConfig references these artifacts:\n",
+      "Artifact(uid='kWwG45Hr26KZUW3g0004', is_latest=True, key='vitessce_examples/habib17.adata.zarr', description='Habib et al., 2017 Nature Methods, zarr', suffix='.anndata.zarr', type='dataset', size=10601062, hash='Ap_EL5yPdfyD07Xjpe1SlA', n_objects=208, _hash_type='md5-d', _accessor='AnnData', visibility=1, _key_is_virtual=True, storage_id=1, transform_id=17, run_id=79, created_by_id=2, created_at=2024-12-04 16:01:11 UTC)\n",
+      "\u001b[92m→\u001b[0m returning existing artifact with same hash: Artifact(uid='J4tMB6qAeHvsgEsp0000', is_latest=True, description='View Habib17 in Vitessce', suffix='.vitessce.json', size=1247, hash='MN-N-I_cn9K8Y2Pe59u1Fw', _hash_type='md5', visibility=1, _key_is_virtual=True, storage_id=1, transform_id=15, run_id=75, created_by_id=2, created_at=2024-12-04 14:32:11 UTC)\n",
+      "\u001b[92m→\u001b[0m VitessceConfig: https://lamin.ai/vitessce/examples/artifact/J4tMB6qAeHvsgEsp0000\n",
+      "\u001b[92m→\u001b[0m Dataset: https://lamin.ai/vitessce/examples/artifact/kWwG45Hr26KZUW3g0004\n"
+     ]
+    }
+   ],
+   "source": [
+    "adata_zarr_vc_artifact = ln.integrations.save_vitessce_config(\n",
+    "    vc, description=\"View Habib17 in Vitessce\",\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 27,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "image/svg+xml": [
+       "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"no\"?>\n",
+       "<!DOCTYPE svg PUBLIC \"-//W3C//DTD SVG 1.1//EN\"\n",
+       " \"http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd\">\n",
+       "<!-- Generated by graphviz version 2.40.1 (20161225.0304)\n",
+       " -->\n",
+       "<!-- Title: artifact_J4tMB6qAeHvsgEsp0000 Pages: 1 -->\n",
+       "<svg width=\"980pt\" height=\"288pt\"\n",
+       " viewBox=\"0.00 0.00 980.41 288.00\" xmlns=\"http://www.w3.org/2000/svg\" xmlns:xlink=\"http://www.w3.org/1999/xlink\">\n",
+       "<g id=\"graph0\" class=\"graph\" transform=\"scale(1 1) rotate(0) translate(4 284)\">\n",
+       "<title>artifact_J4tMB6qAeHvsgEsp0000</title>\n",
+       "<polygon fill=\"#ffffff\" stroke=\"transparent\" points=\"-4,4 -4,-284 976.4097,-284 976.4097,4 -4,4\"/>\n",
+       "<!-- artifact_kWwG45Hr26KZUW3g0004 -->\n",
+       "<g id=\"node1\" class=\"node\">\n",
+       "<title>artifact_kWwG45Hr26KZUW3g0004</title>\n",
+       "<path fill=\"#f0fff0\" stroke=\"#065f46\" d=\"M194.8067,-196C194.8067,-196 12.0644,-196 12.0644,-196 6.0644,-196 .0644,-190 .0644,-184 .0644,-184 .0644,-170 .0644,-170 .0644,-164 6.0644,-158 12.0644,-158 12.0644,-158 194.8067,-158 194.8067,-158 200.8067,-158 206.8067,-164 206.8067,-170 206.8067,-170 206.8067,-184 206.8067,-184 206.8067,-190 200.8067,-196 194.8067,-196\"/>\n",
+       "<text text-anchor=\"start\" x=\"8\" y=\"-185\" font-family=\"Helvetica,sans-Serif\" font-size=\"10.00\" fill=\"#000000\">📄 Habib et al., 2017 Nature Methods, zarr</text>\n",
+       "<text text-anchor=\"start\" x=\"31.3213\" y=\"-175\" font-family=\"Monospace\" font-size=\"10.00\" fill=\"#c0c0c0\">uid=kWwG45Hr26KZUW3g0004</text>\n",
+       "<text text-anchor=\"start\" x=\"59.3828\" y=\"-165\" font-family=\"Monospace\" font-size=\"10.00\" fill=\"#c0c0c0\">suffix=.anndata.zarr</text>\n",
+       "</g>\n",
+       "<!-- run_xZ9HuVQ66i2OBqKlXQ5F -->\n",
+       "<g id=\"node2\" class=\"node\">\n",
+       "<title>run_xZ9HuVQ66i2OBqKlXQ5F</title>\n",
+       "<path fill=\"#dcdcdc\" stroke=\"#065f46\" d=\"M167.9158,-122C167.9158,-122 38.9553,-122 38.9553,-122 32.9553,-122 26.9553,-116 26.9553,-110 26.9553,-110 26.9553,-86 26.9553,-86 26.9553,-80 32.9553,-74 38.9553,-74 38.9553,-74 167.9158,-74 167.9158,-74 173.9158,-74 179.9158,-80 179.9158,-86 179.9158,-86 179.9158,-110 179.9158,-110 179.9158,-116 173.9158,-122 167.9158,-122\"/>\n",
+       "<text text-anchor=\"start\" x=\"48.0195\" y=\"-111\" font-family=\"Helvetica,sans-Serif\" font-size=\"10.00\" fill=\"#000000\">🔧 save_vitessce_config</text>\n",
+       "<text text-anchor=\"start\" x=\"49.4609\" y=\"-101\" font-family=\"Monospace\" font-size=\"10.00\" fill=\"#c0c0c0\">uid=kup03MJBsIVa0002</text>\n",
+       "<text text-anchor=\"start\" x=\"39.2339\" y=\"-91\" font-family=\"Monospace\" font-size=\"10.00\" fill=\"#c0c0c0\">type=function, user=mkeller7</text>\n",
+       "<text text-anchor=\"start\" x=\"35.1958\" y=\"-81\" font-family=\"Monospace\" font-size=\"10.00\" fill=\"#c0c0c0\">run=2024&#45;12&#45;04 16:01:25 UTC</text>\n",
+       "</g>\n",
+       "<!-- artifact_kWwG45Hr26KZUW3g0004&#45;&gt;run_xZ9HuVQ66i2OBqKlXQ5F -->\n",
+       "<g id=\"edge1\" class=\"edge\">\n",
+       "<title>artifact_kWwG45Hr26KZUW3g0004&#45;&gt;run_xZ9HuVQ66i2OBqKlXQ5F</title>\n",
+       "<path fill=\"none\" stroke=\"#696969\" d=\"M103.4355,-157.8763C103.4355,-148.6991 103.4355,-137.5013 103.4355,-127.2829\"/>\n",
+       "<polygon fill=\"#696969\" stroke=\"#696969\" points=\"105.1856,-127.0445 103.4355,-122.0445 101.6856,-127.0445 105.1856,-127.0445\"/>\n",
+       "</g>\n",
+       "<!-- artifact_J4tMB6qAeHvsgEsp0000 -->\n",
+       "<g id=\"node3\" class=\"node\">\n",
+       "<title>artifact_J4tMB6qAeHvsgEsp0000</title>\n",
+       "<path fill=\"#10b981\" stroke=\"#065f46\" d=\"M166.0753,-38C166.0753,-38 40.7958,-38 40.7958,-38 34.7958,-38 28.7958,-32 28.7958,-26 28.7958,-26 28.7958,-12 28.7958,-12 28.7958,-6 34.7958,0 40.7958,0 40.7958,0 166.0753,0 166.0753,0 172.0753,0 178.0753,-6 178.0753,-12 178.0753,-12 178.0753,-26 178.0753,-26 178.0753,-32 172.0753,-38 166.0753,-38\"/>\n",
+       "<text text-anchor=\"start\" x=\"39.3037\" y=\"-27\" font-family=\"Helvetica,sans-Serif\" font-size=\"10.00\" fill=\"#000000\">📄 View Habib17 in Vitessce</text>\n",
+       "<text text-anchor=\"start\" x=\"36.8657\" y=\"-17\" font-family=\"Monospace\" font-size=\"10.00\" fill=\"#c0c0c0\">uid=J4tMB6qAeHvsgEsp0000</text>\n",
+       "<text text-anchor=\"start\" x=\"58.8335\" y=\"-7\" font-family=\"Monospace\" font-size=\"10.00\" fill=\"#c0c0c0\">suffix=.vitessce.json</text>\n",
+       "</g>\n",
+       "<!-- run_xZ9HuVQ66i2OBqKlXQ5F&#45;&gt;artifact_J4tMB6qAeHvsgEsp0000 -->\n",
+       "<g id=\"edge2\" class=\"edge\">\n",
+       "<title>run_xZ9HuVQ66i2OBqKlXQ5F&#45;&gt;artifact_J4tMB6qAeHvsgEsp0000</title>\n",
+       "<path fill=\"none\" stroke=\"#696969\" d=\"M103.4355,-73.8681C103.4355,-64.2201 103.4355,-53.1228 103.4355,-43.4439\"/>\n",
+       "<polygon fill=\"#696969\" stroke=\"#696969\" points=\"105.1856,-43.2308 103.4355,-38.2309 101.6856,-43.2309 105.1856,-43.2308\"/>\n",
+       "</g>\n",
+       "<!-- run_xt2ErUgo7KKqUOOAnVad -->\n",
+       "<g id=\"node4\" class=\"node\">\n",
+       "<title>run_xt2ErUgo7KKqUOOAnVad</title>\n",
+       "<path fill=\"#dcdcdc\" stroke=\"#065f46\" d=\"M537.9158,-280C537.9158,-280 408.9553,-280 408.9553,-280 402.9553,-280 396.9553,-274 396.9553,-268 396.9553,-268 396.9553,-244 396.9553,-244 396.9553,-238 402.9553,-232 408.9553,-232 408.9553,-232 537.9158,-232 537.9158,-232 543.9158,-232 549.9158,-238 549.9158,-244 549.9158,-244 549.9158,-268 549.9158,-268 549.9158,-274 543.9158,-280 537.9158,-280\"/>\n",
+       "<text text-anchor=\"start\" x=\"446.7378\" y=\"-269\" font-family=\"Helvetica,sans-Serif\" font-size=\"10.00\" fill=\"#000000\">📔 Vitessce</text>\n",
+       "<text text-anchor=\"start\" x=\"415.208\" y=\"-259\" font-family=\"Monospace\" font-size=\"10.00\" fill=\"#c0c0c0\">uid=XmcumVqvKZd30002</text>\n",
+       "<text text-anchor=\"start\" x=\"406.1724\" y=\"-249\" font-family=\"Monospace\" font-size=\"10.00\" fill=\"#c0c0c0\">type=notebook, user=mkeller7</text>\n",
+       "<text text-anchor=\"start\" x=\"405.1958\" y=\"-239\" font-family=\"Monospace\" font-size=\"10.00\" fill=\"#c0c0c0\">run=2024&#45;12&#45;04 16:00:56 UTC</text>\n",
+       "</g>\n",
+       "<!-- run_xt2ErUgo7KKqUOOAnVad&#45;&gt;artifact_kWwG45Hr26KZUW3g0004 -->\n",
+       "<g id=\"edge5\" class=\"edge\">\n",
+       "<title>run_xt2ErUgo7KKqUOOAnVad&#45;&gt;artifact_kWwG45Hr26KZUW3g0004</title>\n",
+       "<path fill=\"none\" stroke=\"#696969\" d=\"M396.7713,-239.6311C339.0212,-227.3007 259.5247,-210.3271 197.856,-197.16\"/>\n",
+       "<polygon fill=\"#696969\" stroke=\"#696969\" points=\"197.9534,-195.3915 192.6982,-196.0588 197.2225,-198.8143 197.9534,-195.3915\"/>\n",
+       "</g>\n",
+       "<!-- artifact_1g3a41z0hggWNBrk0000 -->\n",
+       "<g id=\"node5\" class=\"node\">\n",
+       "<title>artifact_1g3a41z0hggWNBrk0000</title>\n",
+       "<path fill=\"#f0fff0\" stroke=\"#065f46\" d=\"M424.3311,-196C424.3311,-196 236.54,-196 236.54,-196 230.54,-196 224.54,-190 224.54,-184 224.54,-184 224.54,-170 224.54,-170 224.54,-164 230.54,-158 236.54,-158 236.54,-158 424.3311,-158 424.3311,-158 430.3311,-158 436.3311,-164 436.3311,-170 436.3311,-170 436.3311,-184 436.3311,-184 436.3311,-190 430.3311,-196 424.3311,-196\"/>\n",
+       "<text text-anchor=\"start\" x=\"232.4878\" y=\"-185\" font-family=\"Helvetica,sans-Serif\" font-size=\"10.00\" fill=\"#000000\">📄 Habib et al., 2017 Nature Methods, h5ad</text>\n",
+       "<text text-anchor=\"start\" x=\"263.5825\" y=\"-175\" font-family=\"Monospace\" font-size=\"10.00\" fill=\"#c0c0c0\">uid=1g3a41z0hggWNBrk0000</text>\n",
+       "<text text-anchor=\"start\" x=\"303.3335\" y=\"-165\" font-family=\"Monospace\" font-size=\"10.00\" fill=\"#c0c0c0\">suffix=.h5ad</text>\n",
+       "</g>\n",
+       "<!-- run_xt2ErUgo7KKqUOOAnVad&#45;&gt;artifact_1g3a41z0hggWNBrk0000 -->\n",
+       "<g id=\"edge3\" class=\"edge\">\n",
+       "<title>run_xt2ErUgo7KKqUOOAnVad&#45;&gt;artifact_1g3a41z0hggWNBrk0000</title>\n",
+       "<path fill=\"none\" stroke=\"#696969\" d=\"M429.7538,-231.8681C410.6726,-221.3267 388.4598,-209.0553 369.8856,-198.7941\"/>\n",
+       "<polygon fill=\"#696969\" stroke=\"#696969\" points=\"370.4687,-197.1169 365.2458,-196.2309 368.7762,-200.1805 370.4687,-197.1169\"/>\n",
+       "</g>\n",
+       "<!-- artifact_O7CTVi6XjnfsceQ20000 -->\n",
+       "<g id=\"node6\" class=\"node\">\n",
+       "<title>artifact_O7CTVi6XjnfsceQ20000</title>\n",
+       "<path fill=\"#f0fff0\" stroke=\"#065f46\" d=\"M766.6339,-196C766.6339,-196 466.2372,-196 466.2372,-196 460.2372,-196 454.2372,-190 454.2372,-184 454.2372,-184 454.2372,-170 454.2372,-170 454.2372,-164 460.2372,-158 466.2372,-158 466.2372,-158 766.6339,-158 766.6339,-158 772.6339,-158 778.6339,-164 778.6339,-170 778.6339,-170 778.6339,-184 778.6339,-184 778.6339,-190 772.6339,-196 766.6339,-196\"/>\n",
+       "<text text-anchor=\"start\" x=\"462.0864\" y=\"-185\" font-family=\"Helvetica,sans-Serif\" font-size=\"10.00\" fill=\"#000000\">📄 Reference JSON for H5AD file, Habib et al., 2017 Nature Methods</text>\n",
+       "<text text-anchor=\"start\" x=\"552.1802\" y=\"-175\" font-family=\"Monospace\" font-size=\"10.00\" fill=\"#c0c0c0\">uid=O7CTVi6XjnfsceQ20000</text>\n",
+       "<text text-anchor=\"start\" x=\"591.2842\" y=\"-165\" font-family=\"Monospace\" font-size=\"10.00\" fill=\"#c0c0c0\">suffix=.json</text>\n",
+       "</g>\n",
+       "<!-- run_xt2ErUgo7KKqUOOAnVad&#45;&gt;artifact_O7CTVi6XjnfsceQ20000 -->\n",
+       "<g id=\"edge4\" class=\"edge\">\n",
+       "<title>run_xt2ErUgo7KKqUOOAnVad&#45;&gt;artifact_O7CTVi6XjnfsceQ20000</title>\n",
+       "<path fill=\"none\" stroke=\"#696969\" d=\"M517.1173,-231.8681C536.1985,-221.3267 558.4113,-209.0553 576.9855,-198.7941\"/>\n",
+       "<polygon fill=\"#696969\" stroke=\"#696969\" points=\"578.0949,-200.1805 581.6252,-196.2309 576.4024,-197.1169 578.0949,-200.1805\"/>\n",
+       "</g>\n",
+       "<!-- collection_obXokdzOnSH2tytJ0000 -->\n",
+       "<g id=\"node7\" class=\"node\">\n",
+       "<title>collection_obXokdzOnSH2tytJ0000</title>\n",
+       "<path fill=\"#f0fff0\" stroke=\"#065f46\" d=\"M960.3838,-196C960.3838,-196 808.4873,-196 808.4873,-196 802.4873,-196 796.4873,-190 796.4873,-184 796.4873,-184 796.4873,-170 796.4873,-170 796.4873,-164 802.4873,-158 808.4873,-158 808.4873,-158 960.3838,-158 960.3838,-158 966.3838,-158 972.3838,-164 972.3838,-170 972.3838,-170 972.3838,-184 972.3838,-184 972.3838,-190 966.3838,-196 960.3838,-196\"/>\n",
+       "<text text-anchor=\"start\" x=\"804.4614\" y=\"-185\" font-family=\"Helvetica,sans-Serif\" font-size=\"10.00\" fill=\"#000000\">🍱 View Habib17 (h5ad) in Vitessce</text>\n",
+       "<text text-anchor=\"start\" x=\"820.0874\" y=\"-175\" font-family=\"Monospace\" font-size=\"10.00\" fill=\"#c0c0c0\">uid=obXokdzOnSH2tytJ0000</text>\n",
+       "<text text-anchor=\"start\" x=\"853.4443\" y=\"-165\" font-family=\"Monospace\" font-size=\"10.00\" fill=\"#c0c0c0\">version=None</text>\n",
+       "</g>\n",
+       "<!-- run_xt2ErUgo7KKqUOOAnVad&#45;&gt;collection_obXokdzOnSH2tytJ0000 -->\n",
+       "<g id=\"edge6\" class=\"edge\">\n",
+       "<title>run_xt2ErUgo7KKqUOOAnVad&#45;&gt;collection_obXokdzOnSH2tytJ0000</title>\n",
+       "<path fill=\"none\" stroke=\"#696969\" d=\"M549.9149,-241.4884C613.5076,-229.3973 706.3822,-211.6821 787.4355,-196 788.7255,-195.7504 790.025,-195.4988 791.3324,-195.2454\"/>\n",
+       "<polygon fill=\"#696969\" stroke=\"#696969\" points=\"791.8353,-196.9306 796.4106,-194.2604 791.1688,-193.4946 791.8353,-196.9306\"/>\n",
+       "</g>\n",
+       "</g>\n",
+       "</svg>\n"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "adata_zarr_vc_artifact.view_lineage()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    ":::{note}\n",
+    "\n",
+    "After running `save_vitessce_config`, a Vitessce button will appear next to the dataset in the [Artifacts](https://lamin.ai/vitessce/examples/artifacts) page of the web interface.\n",
+    "\n",
+    ":::"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Visualize a SpatialData object (Zarr format)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Download and unzip the example SpatialData dataset (approximately 1.47 GB unzipped). Once unzipped, the data will be available via a local Zarr DirectoryStore."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 28,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "sdata_zip_filepath = \"./visium.spatialdata.zarr.zip\"\n",
+    "sdata_zarr_filepath = \"./visium.spatialdata.zarr\"\n",
+    "if not Path(sdata_zarr_filepath).exists():\n",
+    "    if not Path(sdata_zip_filepath).exists():\n",
+    "        urlretrieve(\n",
+    "            \"https://s3.embl.de/spatialdata/spatialdata-sandbox/visium_associated_xenium_io.zip\",\n",
+    "            sdata_zip_filepath,\n",
+    "        )\n",
+    "    with zipfile.ZipFile(sdata_zip_filepath, \"r\") as zip_ref:\n",
+    "        zip_ref.extractall(\".\")\n",
+    "        Path(\"data.zarr\").rename(sdata_zarr_filepath)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Save the dataset"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Save the `.zarr` DirectoryStore as a LaminDB Artifact."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 29,
+   "metadata": {
+    "scrolled": true
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\u001b[92m→\u001b[0m returning existing artifact with same hash: Artifact(uid='nelDyBfwvEIIAKcC0000', is_latest=True, key='vitessce_examples/visium.sdata.zarr', description='Visium SpatialData Example', suffix='.zarr', type='dataset', size=1473180201, hash='BkflAMTiin88wE3Wc84rDQ', n_objects=9167, _hash_type='md5-d', visibility=1, _key_is_virtual=True, storage_id=1, transform_id=16, run_id=73, created_by_id=2, created_at=2024-12-04 13:25:22 UTC)\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "Artifact(uid='nelDyBfwvEIIAKcC0000', is_latest=True, key='vitessce_examples/visium.sdata.zarr', description='Visium SpatialData Example', suffix='.zarr', type='dataset', size=1473180201, hash='BkflAMTiin88wE3Wc84rDQ', n_objects=9167, _hash_type='md5-d', visibility=1, _key_is_virtual=True, storage_id=1, transform_id=17, run_id=79, created_by_id=2, created_at=2024-12-04 13:25:22 UTC)"
+      ]
+     },
+     "execution_count": 29,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "sdata_zarr_artifact = ln.Artifact(\n",
+    "    sdata_zarr_filepath,\n",
+    "    key=\"vitessce_examples/visium.sdata.zarr\",\n",
+    "    description=\"Visium SpatialData Example\",\n",
+    "    type=\"dataset\",\n",
+    ")\n",
+    "sdata_zarr_artifact.save()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Save a VitessceConfig object"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "You can create a dashboard for one or several datasets by using Vitessce's component API.\n",
+    "Here, we use the [SpatialDataWrapper](https://python-docs.vitessce.io/api_data.html#vitessce.wrappers.SpatialDataWrapper) class to specify which parts of the SpatialData object will be loaded for visualization."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 30,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "vc = vit.VitessceConfig(\n",
+    "    schema_version=\"1.0.17\",\n",
+    "    description=sdata_zarr_artifact.description,\n",
+    ")\n",
+    "# Add data to the configuration:\n",
+    "dataset_uid = \"sdata_visium\"\n",
+    "dataset = vc.add_dataset(name='Breast Cancer Visium', uid=dataset_uid).add_object(\n",
+    "    vit.SpatialDataWrapper(\n",
+    "        sdata_artifact=sdata_zarr_artifact,\n",
+    "        # The following paths are relative to the root of the SpatialData zarr store on-disk.\n",
+    "        image_path=\"images/CytAssist_FFPE_Human_Breast_Cancer_full_image\",\n",
+    "        table_path=\"tables/table\",\n",
+    "        obs_feature_matrix_path=\"tables/table/X\",\n",
+    "        obs_spots_path=\"shapes/CytAssist_FFPE_Human_Breast_Cancer\",\n",
+    "        region=\"CytAssist_FFPE_Human_Breast_Cancer\",\n",
+    "        coordinate_system=\"global\",\n",
+    "        coordination_values={\n",
+    "            # The following tells Vitessce to consider each observation as a \"spot\"\n",
+    "            \"obsType\": \"spot\",\n",
+    "        },\n",
+    "    )\n",
+    ")\n",
+    "\n",
+    "# Add views (visualizations) to the configuration:\n",
+    "spatial = vc.add_view(\"spatialBeta\", dataset=dataset)\n",
+    "feature_list = vc.add_view(\"featureList\", dataset=dataset)\n",
+    "layer_controller = vc.add_view(\"layerControllerBeta\", dataset=dataset)\n",
+    "\n",
+    "# Initialize visual properties for multiple linked views:\n",
+    "vc.link_views_by_dict([spatial, layer_controller], {\n",
+    "    \"imageLayer\": vit.CoordinationLevel([{\n",
+    "        \"photometricInterpretation\": \"RGB\",\n",
+    "    }]),\n",
+    "}, scope_prefix=vit.get_initial_coordination_scope_prefix(dataset_uid, \"image\"))\n",
+    "vc.link_views([spatial, layer_controller, feature_list, obs_sets], [\"obsType\"], [\"spot\"])\n",
+    "\n",
+    "# Layout the views\n",
+    "vc.layout(spatial | (feature_list / layer_controller));"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Save the `VitessceConfig` object."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 31,
+   "metadata": {
+    "tags": [
+     "hide-output"
+    ]
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\u001b[92m→\u001b[0m VitessceConfig references these artifacts:\n",
+      "Artifact(uid='nelDyBfwvEIIAKcC0000', is_latest=True, key='vitessce_examples/visium.sdata.zarr', description='Visium SpatialData Example', suffix='.zarr', type='dataset', size=1473180201, hash='BkflAMTiin88wE3Wc84rDQ', n_objects=9167, _hash_type='md5-d', visibility=1, _key_is_virtual=True, storage_id=1, transform_id=17, run_id=79, created_by_id=2, created_at=2024-12-04 13:25:22 UTC)\n",
+      "\u001b[92m→\u001b[0m returning existing artifact with same hash: Artifact(uid='Xot2a5ZAcTW3fClG0000', is_latest=True, description='View Visium SpatialData Example in Vitessce', suffix='.vitessce.json', size=1845, hash='PirnTDMPxYDC9ajti_St4g', _hash_type='md5', visibility=1, _key_is_virtual=True, storage_id=1, transform_id=15, run_id=76, created_by_id=2, created_at=2024-12-04 15:53:06 UTC)\n",
+      "\u001b[92m→\u001b[0m VitessceConfig: https://lamin.ai/vitessce/examples/artifact/Xot2a5ZAcTW3fClG0000\n",
+      "\u001b[92m→\u001b[0m Dataset: https://lamin.ai/vitessce/examples/artifact/nelDyBfwvEIIAKcC0000\n"
+     ]
+    }
+   ],
+   "source": [
+    "sdata_vc_artifact = ln.integrations.save_vitessce_config(\n",
+    "    vc, description=\"View Visium SpatialData Example in Vitessce\",\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 32,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "image/svg+xml": [
+       "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"no\"?>\n",
+       "<!DOCTYPE svg PUBLIC \"-//W3C//DTD SVG 1.1//EN\"\n",
+       " \"http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd\">\n",
+       "<!-- Generated by graphviz version 2.40.1 (20161225.0304)\n",
+       " -->\n",
+       "<!-- Title: artifact_Xot2a5ZAcTW3fClG0000 Pages: 1 -->\n",
+       "<svg width=\"1194pt\" height=\"288pt\"\n",
+       " viewBox=\"0.00 0.00 1194.48 288.00\" xmlns=\"http://www.w3.org/2000/svg\" xmlns:xlink=\"http://www.w3.org/1999/xlink\">\n",
+       "<g id=\"graph0\" class=\"graph\" transform=\"scale(1 1) rotate(0) translate(4 284)\">\n",
+       "<title>artifact_Xot2a5ZAcTW3fClG0000</title>\n",
+       "<polygon fill=\"#ffffff\" stroke=\"transparent\" points=\"-4,4 -4,-284 1190.4761,-284 1190.4761,4 -4,4\"/>\n",
+       "<!-- artifact_nelDyBfwvEIIAKcC0000 -->\n",
+       "<g id=\"node1\" class=\"node\">\n",
+       "<title>artifact_nelDyBfwvEIIAKcC0000</title>\n",
+       "<path fill=\"#f0fff0\" stroke=\"#065f46\" d=\"M183.2717,-196C183.2717,-196 49.7323,-196 49.7323,-196 43.7323,-196 37.7323,-190 37.7323,-184 37.7323,-184 37.7323,-170 37.7323,-170 37.7323,-164 43.7323,-158 49.7323,-158 49.7323,-158 183.2717,-158 183.2717,-158 189.2717,-158 195.2717,-164 195.2717,-170 195.2717,-170 195.2717,-184 195.2717,-184 195.2717,-190 189.2717,-196 183.2717,-196\"/>\n",
+       "<text text-anchor=\"start\" x=\"45.6172\" y=\"-185\" font-family=\"Helvetica,sans-Serif\" font-size=\"10.00\" fill=\"#000000\">📄 Visium SpatialData Example</text>\n",
+       "<text text-anchor=\"start\" x=\"53.2744\" y=\"-175\" font-family=\"Monospace\" font-size=\"10.00\" fill=\"#c0c0c0\">uid=nelDyBfwvEIIAKcC0000</text>\n",
+       "<text text-anchor=\"start\" x=\"91.9121\" y=\"-165\" font-family=\"Monospace\" font-size=\"10.00\" fill=\"#c0c0c0\">suffix=.zarr</text>\n",
+       "</g>\n",
+       "<!-- run_yE0u9JC40liWx6H7jfAT -->\n",
+       "<g id=\"node2\" class=\"node\">\n",
+       "<title>run_yE0u9JC40liWx6H7jfAT</title>\n",
+       "<path fill=\"#dcdcdc\" stroke=\"#065f46\" d=\"M180.9822,-122C180.9822,-122 52.0217,-122 52.0217,-122 46.0217,-122 40.0217,-116 40.0217,-110 40.0217,-110 40.0217,-86 40.0217,-86 40.0217,-80 46.0217,-74 52.0217,-74 52.0217,-74 180.9822,-74 180.9822,-74 186.9822,-74 192.9822,-80 192.9822,-86 192.9822,-86 192.9822,-110 192.9822,-110 192.9822,-116 186.9822,-122 180.9822,-122\"/>\n",
+       "<text text-anchor=\"start\" x=\"61.0859\" y=\"-111\" font-family=\"Helvetica,sans-Serif\" font-size=\"10.00\" fill=\"#000000\">🔧 save_vitessce_config</text>\n",
+       "<text text-anchor=\"start\" x=\"62.5273\" y=\"-101\" font-family=\"Monospace\" font-size=\"10.00\" fill=\"#c0c0c0\">uid=kup03MJBsIVa0002</text>\n",
+       "<text text-anchor=\"start\" x=\"52.3003\" y=\"-91\" font-family=\"Monospace\" font-size=\"10.00\" fill=\"#c0c0c0\">type=function, user=mkeller7</text>\n",
+       "<text text-anchor=\"start\" x=\"48.2622\" y=\"-81\" font-family=\"Monospace\" font-size=\"10.00\" fill=\"#c0c0c0\">run=2024&#45;12&#45;04 16:01:32 UTC</text>\n",
+       "</g>\n",
+       "<!-- artifact_nelDyBfwvEIIAKcC0000&#45;&gt;run_yE0u9JC40liWx6H7jfAT -->\n",
+       "<g id=\"edge1\" class=\"edge\">\n",
+       "<title>artifact_nelDyBfwvEIIAKcC0000&#45;&gt;run_yE0u9JC40liWx6H7jfAT</title>\n",
+       "<path fill=\"none\" stroke=\"#696969\" d=\"M116.502,-157.8763C116.502,-148.6991 116.502,-137.5013 116.502,-127.2829\"/>\n",
+       "<polygon fill=\"#696969\" stroke=\"#696969\" points=\"118.252,-127.0445 116.502,-122.0445 114.752,-127.0445 118.252,-127.0445\"/>\n",
+       "</g>\n",
+       "<!-- artifact_Xot2a5ZAcTW3fClG0000 -->\n",
+       "<g id=\"node3\" class=\"node\">\n",
+       "<title>artifact_Xot2a5ZAcTW3fClG0000</title>\n",
+       "<path fill=\"#10b981\" stroke=\"#065f46\" d=\"M221.0059,-38C221.0059,-38 11.998,-38 11.998,-38 5.998,-38 -.002,-32 -.002,-26 -.002,-26 -.002,-12 -.002,-12 -.002,-6 5.998,0 11.998,0 11.998,0 221.0059,0 221.0059,0 227.0059,0 233.0059,-6 233.0059,-12 233.0059,-12 233.0059,-26 233.0059,-26 233.0059,-32 227.0059,-38 221.0059,-38\"/>\n",
+       "<text text-anchor=\"start\" x=\"8\" y=\"-27\" font-family=\"Helvetica,sans-Serif\" font-size=\"10.00\" fill=\"#000000\">📄 View Visium SpatialData Example in Vitessce</text>\n",
+       "<text text-anchor=\"start\" x=\"50.4961\" y=\"-17\" font-family=\"Monospace\" font-size=\"10.00\" fill=\"#c0c0c0\">uid=Xot2a5ZAcTW3fClG0000</text>\n",
+       "<text text-anchor=\"start\" x=\"71.8999\" y=\"-7\" font-family=\"Monospace\" font-size=\"10.00\" fill=\"#c0c0c0\">suffix=.vitessce.json</text>\n",
+       "</g>\n",
+       "<!-- run_yE0u9JC40liWx6H7jfAT&#45;&gt;artifact_Xot2a5ZAcTW3fClG0000 -->\n",
+       "<g id=\"edge2\" class=\"edge\">\n",
+       "<title>run_yE0u9JC40liWx6H7jfAT&#45;&gt;artifact_Xot2a5ZAcTW3fClG0000</title>\n",
+       "<path fill=\"none\" stroke=\"#696969\" d=\"M116.502,-73.8681C116.502,-64.2201 116.502,-53.1228 116.502,-43.4439\"/>\n",
+       "<polygon fill=\"#696969\" stroke=\"#696969\" points=\"118.252,-43.2308 116.502,-38.2309 114.752,-43.2309 118.252,-43.2308\"/>\n",
+       "</g>\n",
+       "<!-- run_xt2ErUgo7KKqUOOAnVad -->\n",
+       "<g id=\"node4\" class=\"node\">\n",
+       "<title>run_xt2ErUgo7KKqUOOAnVad</title>\n",
+       "<path fill=\"#dcdcdc\" stroke=\"#065f46\" d=\"M669.9822,-280C669.9822,-280 541.0217,-280 541.0217,-280 535.0217,-280 529.0217,-274 529.0217,-268 529.0217,-268 529.0217,-244 529.0217,-244 529.0217,-238 535.0217,-232 541.0217,-232 541.0217,-232 669.9822,-232 669.9822,-232 675.9822,-232 681.9822,-238 681.9822,-244 681.9822,-244 681.9822,-268 681.9822,-268 681.9822,-274 675.9822,-280 669.9822,-280\"/>\n",
+       "<text text-anchor=\"start\" x=\"578.8042\" y=\"-269\" font-family=\"Helvetica,sans-Serif\" font-size=\"10.00\" fill=\"#000000\">📔 Vitessce</text>\n",
+       "<text text-anchor=\"start\" x=\"547.2744\" y=\"-259\" font-family=\"Monospace\" font-size=\"10.00\" fill=\"#c0c0c0\">uid=XmcumVqvKZd30002</text>\n",
+       "<text text-anchor=\"start\" x=\"538.2388\" y=\"-249\" font-family=\"Monospace\" font-size=\"10.00\" fill=\"#c0c0c0\">type=notebook, user=mkeller7</text>\n",
+       "<text text-anchor=\"start\" x=\"537.2622\" y=\"-239\" font-family=\"Monospace\" font-size=\"10.00\" fill=\"#c0c0c0\">run=2024&#45;12&#45;04 16:00:56 UTC</text>\n",
+       "</g>\n",
+       "<!-- run_xt2ErUgo7KKqUOOAnVad&#45;&gt;artifact_nelDyBfwvEIIAKcC0000 -->\n",
+       "<g id=\"edge3\" class=\"edge\">\n",
+       "<title>run_xt2ErUgo7KKqUOOAnVad&#45;&gt;artifact_nelDyBfwvEIIAKcC0000</title>\n",
+       "<path fill=\"none\" stroke=\"#696969\" d=\"M529.1332,-246.057C448.2745,-235.1829 317.0306,-216.5447 204.502,-196 203.2239,-195.7667 201.936,-195.5284 200.6403,-195.2859\"/>\n",
+       "<polygon fill=\"#696969\" stroke=\"#696969\" points=\"200.847,-193.5439 195.6082,-194.3302 200.1938,-196.9825 200.847,-193.5439\"/>\n",
+       "</g>\n",
+       "<!-- artifact_1g3a41z0hggWNBrk0000 -->\n",
+       "<g id=\"node5\" class=\"node\">\n",
+       "<title>artifact_1g3a41z0hggWNBrk0000</title>\n",
+       "<path fill=\"#f0fff0\" stroke=\"#065f46\" d=\"M413.3975,-196C413.3975,-196 225.6064,-196 225.6064,-196 219.6064,-196 213.6064,-190 213.6064,-184 213.6064,-184 213.6064,-170 213.6064,-170 213.6064,-164 219.6064,-158 225.6064,-158 225.6064,-158 413.3975,-158 413.3975,-158 419.3975,-158 425.3975,-164 425.3975,-170 425.3975,-170 425.3975,-184 425.3975,-184 425.3975,-190 419.3975,-196 413.3975,-196\"/>\n",
+       "<text text-anchor=\"start\" x=\"221.5542\" y=\"-185\" font-family=\"Helvetica,sans-Serif\" font-size=\"10.00\" fill=\"#000000\">📄 Habib et al., 2017 Nature Methods, h5ad</text>\n",
+       "<text text-anchor=\"start\" x=\"252.6489\" y=\"-175\" font-family=\"Monospace\" font-size=\"10.00\" fill=\"#c0c0c0\">uid=1g3a41z0hggWNBrk0000</text>\n",
+       "<text text-anchor=\"start\" x=\"292.3999\" y=\"-165\" font-family=\"Monospace\" font-size=\"10.00\" fill=\"#c0c0c0\">suffix=.h5ad</text>\n",
+       "</g>\n",
+       "<!-- run_xt2ErUgo7KKqUOOAnVad&#45;&gt;artifact_1g3a41z0hggWNBrk0000 -->\n",
+       "<g id=\"edge4\" class=\"edge\">\n",
+       "<title>run_xt2ErUgo7KKqUOOAnVad&#45;&gt;artifact_1g3a41z0hggWNBrk0000</title>\n",
+       "<path fill=\"none\" stroke=\"#696969\" d=\"M529.2349,-234.9332C487.2559,-223.3376 435.3865,-209.0101 393.7337,-197.5046\"/>\n",
+       "<polygon fill=\"#696969\" stroke=\"#696969\" points=\"393.9916,-195.7603 388.7061,-196.1158 393.0596,-199.134 393.9916,-195.7603\"/>\n",
+       "</g>\n",
+       "<!-- artifact_O7CTVi6XjnfsceQ20000 -->\n",
+       "<g id=\"node6\" class=\"node\">\n",
+       "<title>artifact_O7CTVi6XjnfsceQ20000</title>\n",
+       "<path fill=\"#f0fff0\" stroke=\"#065f46\" d=\"M755.7003,-196C755.7003,-196 455.3036,-196 455.3036,-196 449.3036,-196 443.3036,-190 443.3036,-184 443.3036,-184 443.3036,-170 443.3036,-170 443.3036,-164 449.3036,-158 455.3036,-158 455.3036,-158 755.7003,-158 755.7003,-158 761.7003,-158 767.7003,-164 767.7003,-170 767.7003,-170 767.7003,-184 767.7003,-184 767.7003,-190 761.7003,-196 755.7003,-196\"/>\n",
+       "<text text-anchor=\"start\" x=\"451.1528\" y=\"-185\" font-family=\"Helvetica,sans-Serif\" font-size=\"10.00\" fill=\"#000000\">📄 Reference JSON for H5AD file, Habib et al., 2017 Nature Methods</text>\n",
+       "<text text-anchor=\"start\" x=\"541.2466\" y=\"-175\" font-family=\"Monospace\" font-size=\"10.00\" fill=\"#c0c0c0\">uid=O7CTVi6XjnfsceQ20000</text>\n",
+       "<text text-anchor=\"start\" x=\"580.3506\" y=\"-165\" font-family=\"Monospace\" font-size=\"10.00\" fill=\"#c0c0c0\">suffix=.json</text>\n",
+       "</g>\n",
+       "<!-- run_xt2ErUgo7KKqUOOAnVad&#45;&gt;artifact_O7CTVi6XjnfsceQ20000 -->\n",
+       "<g id=\"edge5\" class=\"edge\">\n",
+       "<title>run_xt2ErUgo7KKqUOOAnVad&#45;&gt;artifact_O7CTVi6XjnfsceQ20000</title>\n",
+       "<path fill=\"none\" stroke=\"#696969\" d=\"M605.502,-231.8681C605.502,-222.2201 605.502,-211.1228 605.502,-201.4439\"/>\n",
+       "<polygon fill=\"#696969\" stroke=\"#696969\" points=\"607.252,-201.2308 605.502,-196.2309 603.752,-201.2309 607.252,-201.2308\"/>\n",
+       "</g>\n",
+       "<!-- artifact_kWwG45Hr26KZUW3g0004 -->\n",
+       "<g id=\"node7\" class=\"node\">\n",
+       "<title>artifact_kWwG45Hr26KZUW3g0004</title>\n",
+       "<path fill=\"#f0fff0\" stroke=\"#065f46\" d=\"M980.8731,-196C980.8731,-196 798.1308,-196 798.1308,-196 792.1308,-196 786.1308,-190 786.1308,-184 786.1308,-184 786.1308,-170 786.1308,-170 786.1308,-164 792.1308,-158 798.1308,-158 798.1308,-158 980.8731,-158 980.8731,-158 986.8731,-158 992.8731,-164 992.8731,-170 992.8731,-170 992.8731,-184 992.8731,-184 992.8731,-190 986.8731,-196 980.8731,-196\"/>\n",
+       "<text text-anchor=\"start\" x=\"794.0664\" y=\"-185\" font-family=\"Helvetica,sans-Serif\" font-size=\"10.00\" fill=\"#000000\">📄 Habib et al., 2017 Nature Methods, zarr</text>\n",
+       "<text text-anchor=\"start\" x=\"817.3877\" y=\"-175\" font-family=\"Monospace\" font-size=\"10.00\" fill=\"#c0c0c0\">uid=kWwG45Hr26KZUW3g0004</text>\n",
+       "<text text-anchor=\"start\" x=\"845.4492\" y=\"-165\" font-family=\"Monospace\" font-size=\"10.00\" fill=\"#c0c0c0\">suffix=.anndata.zarr</text>\n",
+       "</g>\n",
+       "<!-- run_xt2ErUgo7KKqUOOAnVad&#45;&gt;artifact_kWwG45Hr26KZUW3g0004 -->\n",
+       "<g id=\"edge6\" class=\"edge\">\n",
+       "<title>run_xt2ErUgo7KKqUOOAnVad&#45;&gt;artifact_kWwG45Hr26KZUW3g0004</title>\n",
+       "<path fill=\"none\" stroke=\"#696969\" d=\"M681.9823,-234.7255C723.6607,-223.1319 774.984,-208.8553 816.1623,-197.4008\"/>\n",
+       "<polygon fill=\"#696969\" stroke=\"#696969\" points=\"816.7843,-199.0443 821.1324,-196.0183 815.8463,-195.6723 816.7843,-199.0443\"/>\n",
+       "</g>\n",
+       "<!-- collection_obXokdzOnSH2tytJ0000 -->\n",
+       "<g id=\"node8\" class=\"node\">\n",
+       "<title>collection_obXokdzOnSH2tytJ0000</title>\n",
+       "<path fill=\"#f0fff0\" stroke=\"#065f46\" d=\"M1174.4502,-196C1174.4502,-196 1022.5537,-196 1022.5537,-196 1016.5537,-196 1010.5537,-190 1010.5537,-184 1010.5537,-184 1010.5537,-170 1010.5537,-170 1010.5537,-164 1016.5537,-158 1022.5537,-158 1022.5537,-158 1174.4502,-158 1174.4502,-158 1180.4502,-158 1186.4502,-164 1186.4502,-170 1186.4502,-170 1186.4502,-184 1186.4502,-184 1186.4502,-190 1180.4502,-196 1174.4502,-196\"/>\n",
+       "<text text-anchor=\"start\" x=\"1018.5278\" y=\"-185\" font-family=\"Helvetica,sans-Serif\" font-size=\"10.00\" fill=\"#000000\">🍱 View Habib17 (h5ad) in Vitessce</text>\n",
+       "<text text-anchor=\"start\" x=\"1034.1538\" y=\"-175\" font-family=\"Monospace\" font-size=\"10.00\" fill=\"#c0c0c0\">uid=obXokdzOnSH2tytJ0000</text>\n",
+       "<text text-anchor=\"start\" x=\"1067.5107\" y=\"-165\" font-family=\"Monospace\" font-size=\"10.00\" fill=\"#c0c0c0\">version=None</text>\n",
+       "</g>\n",
+       "<!-- run_xt2ErUgo7KKqUOOAnVad&#45;&gt;collection_obXokdzOnSH2tytJ0000 -->\n",
+       "<g id=\"edge7\" class=\"edge\">\n",
+       "<title>run_xt2ErUgo7KKqUOOAnVad&#45;&gt;collection_obXokdzOnSH2tytJ0000</title>\n",
+       "<path fill=\"none\" stroke=\"#696969\" d=\"M681.9452,-245.4134C761.8162,-234.1191 890.6873,-215.2388 1001.502,-196 1002.7964,-195.7753 1004.1002,-195.547 1005.4116,-195.3155\"/>\n",
+       "<polygon fill=\"#696969\" stroke=\"#696969\" points=\"1005.8886,-197.0082 1010.5041,-194.4082 1005.2746,-193.5625 1005.8886,-197.0082\"/>\n",
+       "</g>\n",
+       "</g>\n",
+       "</svg>\n"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "sdata_vc_artifact.view_lineage()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    ":::{note}\n",
+    "\n",
+    "After running `save_vitessce_config`, a Vitessce button will appear next to the dataset in the [Artifacts](https://lamin.ai/vitessce/examples/artifacts) page of the web interface.\n",
+    "\n",
+    ":::"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Visualize an image (OME-TIFF format)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Vitesse can visualize data from multiple bioimaging file formats, including [OME-TIFF](https://ome-model.readthedocs.io/en/stable/ome-tiff/)."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Here, we download an example OME-TIFF file (approximately 1.02 GB)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 33,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "ome_tiff_filepath = \"./VAN0006-LK-2-85-PAS_registered.ome.tif\"\n",
+    "if not Path(ome_tiff_filepath).exists():\n",
+    "    urlretrieve(\n",
+    "        \"https://assets.hubmapconsortium.org/f4188a148e4c759092d19369d310883b/ometiff-pyramids/processedMicroscopy/VAN0006-LK-2-85-PAS_images/VAN0006-LK-2-85-PAS_registered.ome.tif\",\n",
+    "        ome_tiff_filepath,\n",
+    "    )"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Save the dataset"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Save the `.ome.tif` file as a LaminDB Artifact."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 34,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\u001b[92m→\u001b[0m returning existing artifact with same hash: Artifact(uid='0I5aMNdh2UrECtFX0000', is_latest=True, key='vitessce_examples/VAN0006-LK-2-85-PAS_registered.ome.tif', description='PAS OME-TIFF file, Neumann et al., 2020', suffix='.tif', type='dataset', size=1021561156, hash='pa3FYqKL6afG8PduprhRJk', _hash_type='sha1-fl', visibility=1, _key_is_virtual=True, storage_id=1, transform_id=16, run_id=73, created_by_id=2, created_at=2024-10-05 20:00:49 UTC)\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "Artifact(uid='0I5aMNdh2UrECtFX0000', is_latest=True, key='vitessce_examples/VAN0006-LK-2-85-PAS_registered.ome.tif', description='PAS OME-TIFF file, Neumann et al., 2020', suffix='.tif', type='dataset', size=1021561156, hash='pa3FYqKL6afG8PduprhRJk', _hash_type='sha1-fl', visibility=1, _key_is_virtual=True, storage_id=1, transform_id=17, run_id=79, created_by_id=2, created_at=2024-10-05 20:00:49 UTC)"
+      ]
+     },
+     "execution_count": 34,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "ome_tiff_artifact = ln.Artifact(\n",
+    "    ome_tiff_filepath,\n",
+    "    key=\"vitessce_examples/VAN0006-LK-2-85-PAS_registered.ome.tif\",\n",
+    "    description=\"PAS OME-TIFF file, Neumann et al., 2020\",\n",
+    "    type=\"dataset\",\n",
+    ")\n",
+    "ome_tiff_artifact.save()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "When using OME-TIFF files, we can use [generate-tiff-offsets](https://github.com/hms-dbmi/generate-tiff-offsets) to create an index for the bytes within the OME-TIFF file. We store these to a companion `.offsets.json` file which makes loading subsets of the image more efficient."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 35,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "offsets = get_offsets(ome_tiff_filepath)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 36,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\u001b[92m→\u001b[0m returning existing artifact with same hash: Artifact(uid='CMBUzbNNCEDGCKcQ0000', is_latest=True, key='vitessce_examples/VAN0006-LK-2-85-PAS_registered.offsets.json', description='PAS offsets file, Neumann et al., 2020', suffix='.json', type='dataset', size=36, hash='5ADv5d7DI5oYVaMOPnhqiw', _hash_type='md5', visibility=1, _key_is_virtual=True, storage_id=1, transform_id=16, run_id=73, created_by_id=2, created_at=2024-10-05 20:18:38 UTC)\n"
+     ]
+    }
+   ],
+   "source": [
+    "offsets_path = \"./VAN0006-LK-2-85-PAS_registered.offsets.json\"\n",
+    "with open(offsets_path, \"w\") as file:\n",
+    "    json.dump(offsets, file)\n",
+    "offsets_artifact = ln.Artifact(\n",
+    "    offsets_path,\n",
+    "    key=\"vitessce_examples/VAN0006-LK-2-85-PAS_registered.offsets.json\",\n",
+    "    description=\"PAS offsets file, Neumann et al., 2020\"\n",
+    ").save()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Save a VitessceConfig object"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "You can create a dashboard for one or several datasets by using Vitessce's component API.\n",
+    "Here, we use the [ImageOmeTiffWrapper](https://python-docs.vitessce.io/api_data.html#vitessce.wrappers.ImageOmeTiffWrapper) class to specify which pair of OME-TIFF file and offsets JSON file to load."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 37,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "vc = vit.VitessceConfig(\n",
+    "    schema_version=\"1.0.17\",\n",
+    "    description=ome_tiff_artifact.description\n",
+    ")\n",
+    "dataset = vc.add_dataset(\"Image\").add_object(\n",
+    "    vit.ImageOmeTiffWrapper(\n",
+    "        img_artifact=ome_tiff_artifact,\n",
+    "        offsets_artifact=offsets_artifact,\n",
+    "    )\n",
+    ")\n",
+    "spatial = vc.add_view(\"spatialBeta\", dataset=dataset)\n",
+    "layer_controller = vc.add_view(\"layerControllerBeta\", dataset=dataset)\n",
+    "vc.layout(spatial | layer_controller);"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Save the `VitessceConfig` object."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 38,
+   "metadata": {
+    "tags": [
+     "hide-output"
+    ]
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\u001b[92m→\u001b[0m VitessceConfig references these artifacts:\n",
+      "Artifact(uid='0I5aMNdh2UrECtFX0000', is_latest=True, key='vitessce_examples/VAN0006-LK-2-85-PAS_registered.ome.tif', description='PAS OME-TIFF file, Neumann et al., 2020', suffix='.tif', type='dataset', size=1021561156, hash='pa3FYqKL6afG8PduprhRJk', _hash_type='sha1-fl', visibility=1, _key_is_virtual=True, storage_id=1, transform_id=17, run_id=79, created_by_id=2, created_at=2024-10-05 20:00:49 UTC)\n",
+      "Artifact(uid='CMBUzbNNCEDGCKcQ0000', is_latest=True, key='vitessce_examples/VAN0006-LK-2-85-PAS_registered.offsets.json', description='PAS offsets file, Neumann et al., 2020', suffix='.json', type='dataset', size=36, hash='5ADv5d7DI5oYVaMOPnhqiw', _hash_type='md5', visibility=1, _key_is_virtual=True, storage_id=1, transform_id=17, run_id=79, created_by_id=2, created_at=2024-10-05 20:18:38 UTC)\n",
+      "\u001b[93m!\u001b[0m returning existing collection with same hash: Collection(uid='HqfzZmkfYOy20ZNN0000', is_latest=True, name='View PAS OME-TIFF, Neumann et al., 2020 in Vitessce', hash='vpleElXxZiaZblQ09q9K-g', visibility=1, created_by_id=2, transform_id=16, run_id=73, created_at=2024-10-05 20:49:25 UTC)\n",
+      "\u001b[92m→\u001b[0m returning existing artifact with same hash: Artifact(uid='QtF1OEtYyUe1EQ1k0000', is_latest=True, description='View PAS OME-TIFF, Neumann et al., 2020 in Vitessce', suffix='.vitessce.json', size=724, hash='SzO9Fq5iH2Xhz76j-qTjvg', _hash_type='md5', visibility=1, _key_is_virtual=True, storage_id=1, transform_id=15, run_id=77, created_by_id=2, created_at=2024-12-04 14:34:20 UTC)\n",
+      "\u001b[92m→\u001b[0m VitessceConfig: https://lamin.ai/vitessce/examples/artifact/QtF1OEtYyUe1EQ1k0000\n",
+      "\u001b[92m→\u001b[0m Collection: https://lamin.ai/vitessce/examples/collection/HqfzZmkfYOy20ZNN0000\n"
+     ]
+    }
+   ],
+   "source": [
+    "ome_tiff_vc_artifact = ln.integrations.save_vitessce_config(\n",
+    "    vc, description=\"View PAS OME-TIFF, Neumann et al., 2020 in Vitessce\",\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 39,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "image/svg+xml": [
+       "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"no\"?>\n",
+       "<!DOCTYPE svg PUBLIC \"-//W3C//DTD SVG 1.1//EN\"\n",
+       " \"http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd\">\n",
+       "<!-- Generated by graphviz version 2.40.1 (20161225.0304)\n",
+       " -->\n",
+       "<!-- Title: artifact_QtF1OEtYyUe1EQ1k0000 Pages: 1 -->\n",
+       "<svg width=\"1905pt\" height=\"288pt\"\n",
+       " viewBox=\"0.00 0.00 1905.06 288.00\" xmlns=\"http://www.w3.org/2000/svg\" xmlns:xlink=\"http://www.w3.org/1999/xlink\">\n",
+       "<g id=\"graph0\" class=\"graph\" transform=\"scale(1 1) rotate(0) translate(4 284)\">\n",
+       "<title>artifact_QtF1OEtYyUe1EQ1k0000</title>\n",
+       "<polygon fill=\"#ffffff\" stroke=\"transparent\" points=\"-4,4 -4,-284 1901.0615,-284 1901.0615,4 -4,4\"/>\n",
+       "<!-- artifact_0I5aMNdh2UrECtFX0000 -->\n",
+       "<g id=\"node1\" class=\"node\">\n",
+       "<title>artifact_0I5aMNdh2UrECtFX0000</title>\n",
+       "<path fill=\"#f0fff0\" stroke=\"#065f46\" d=\"M205.6691,-196C205.6691,-196 12.1102,-196 12.1102,-196 6.1102,-196 .1102,-190 .1102,-184 .1102,-184 .1102,-170 .1102,-170 .1102,-164 6.1102,-158 12.1102,-158 12.1102,-158 205.6691,-158 205.6691,-158 211.6691,-158 217.6691,-164 217.6691,-170 217.6691,-170 217.6691,-184 217.6691,-184 217.6691,-190 211.6691,-196 205.6691,-196\"/>\n",
+       "<text text-anchor=\"start\" x=\"8\" y=\"-185\" font-family=\"Helvetica,sans-Serif\" font-size=\"10.00\" fill=\"#000000\">📄 PAS OME&#45;TIFF file, Neumann et al., 2020</text>\n",
+       "<text text-anchor=\"start\" x=\"42.3247\" y=\"-175\" font-family=\"Monospace\" font-size=\"10.00\" fill=\"#c0c0c0\">uid=0I5aMNdh2UrECtFX0000</text>\n",
+       "<text text-anchor=\"start\" x=\"89.0215\" y=\"-165\" font-family=\"Monospace\" font-size=\"10.00\" fill=\"#c0c0c0\">suffix=.tif</text>\n",
+       "</g>\n",
+       "<!-- run_DZlFDV3T7syiFOXMkcHn -->\n",
+       "<g id=\"node2\" class=\"node\">\n",
+       "<title>run_DZlFDV3T7syiFOXMkcHn</title>\n",
+       "<path fill=\"#dcdcdc\" stroke=\"#065f46\" d=\"M286.3699,-122C286.3699,-122 157.4094,-122 157.4094,-122 151.4094,-122 145.4094,-116 145.4094,-110 145.4094,-110 145.4094,-86 145.4094,-86 145.4094,-80 151.4094,-74 157.4094,-74 157.4094,-74 286.3699,-74 286.3699,-74 292.3699,-74 298.3699,-80 298.3699,-86 298.3699,-86 298.3699,-110 298.3699,-110 298.3699,-116 292.3699,-122 286.3699,-122\"/>\n",
+       "<text text-anchor=\"start\" x=\"166.4736\" y=\"-111\" font-family=\"Helvetica,sans-Serif\" font-size=\"10.00\" fill=\"#000000\">🔧 save_vitessce_config</text>\n",
+       "<text text-anchor=\"start\" x=\"167.915\" y=\"-101\" font-family=\"Monospace\" font-size=\"10.00\" fill=\"#c0c0c0\">uid=kup03MJBsIVa0002</text>\n",
+       "<text text-anchor=\"start\" x=\"157.688\" y=\"-91\" font-family=\"Monospace\" font-size=\"10.00\" fill=\"#c0c0c0\">type=function, user=mkeller7</text>\n",
+       "<text text-anchor=\"start\" x=\"153.6499\" y=\"-81\" font-family=\"Monospace\" font-size=\"10.00\" fill=\"#c0c0c0\">run=2024&#45;12&#45;04 16:01:38 UTC</text>\n",
+       "</g>\n",
+       "<!-- artifact_0I5aMNdh2UrECtFX0000&#45;&gt;run_DZlFDV3T7syiFOXMkcHn -->\n",
+       "<g id=\"edge1\" class=\"edge\">\n",
+       "<title>artifact_0I5aMNdh2UrECtFX0000&#45;&gt;run_DZlFDV3T7syiFOXMkcHn</title>\n",
+       "<path fill=\"none\" stroke=\"#696969\" d=\"M136.2438,-157.8763C150.3341,-148.0256 167.7546,-135.8466 183.1979,-125.05\"/>\n",
+       "<polygon fill=\"#696969\" stroke=\"#696969\" points=\"184.4017,-126.3437 187.4969,-122.0445 182.3963,-123.4752 184.4017,-126.3437\"/>\n",
+       "</g>\n",
+       "<!-- artifact_QtF1OEtYyUe1EQ1k0000 -->\n",
+       "<g id=\"node4\" class=\"node\">\n",
+       "<title>artifact_QtF1OEtYyUe1EQ1k0000</title>\n",
+       "<path fill=\"#10b981\" stroke=\"#065f46\" d=\"M348.2336,-38C348.2336,-38 95.5457,-38 95.5457,-38 89.5457,-38 83.5457,-32 83.5457,-26 83.5457,-26 83.5457,-12 83.5457,-12 83.5457,-6 89.5457,0 95.5457,0 95.5457,0 348.2336,0 348.2336,0 354.2336,0 360.2336,-6 360.2336,-12 360.2336,-12 360.2336,-26 360.2336,-26 360.2336,-32 354.2336,-38 348.2336,-38\"/>\n",
+       "<text text-anchor=\"start\" x=\"91.7178\" y=\"-27\" font-family=\"Helvetica,sans-Serif\" font-size=\"10.00\" fill=\"#000000\">📄 View PAS OME&#45;TIFF, Neumann et al., 2020 in Vitessce</text>\n",
+       "<text text-anchor=\"start\" x=\"153.9355\" y=\"-17\" font-family=\"Monospace\" font-size=\"10.00\" fill=\"#c0c0c0\">uid=QtF1OEtYyUe1EQ1k0000</text>\n",
+       "<text text-anchor=\"start\" x=\"177.2876\" y=\"-7\" font-family=\"Monospace\" font-size=\"10.00\" fill=\"#c0c0c0\">suffix=.vitessce.json</text>\n",
+       "</g>\n",
+       "<!-- run_DZlFDV3T7syiFOXMkcHn&#45;&gt;artifact_QtF1OEtYyUe1EQ1k0000 -->\n",
+       "<g id=\"edge3\" class=\"edge\">\n",
+       "<title>run_DZlFDV3T7syiFOXMkcHn&#45;&gt;artifact_QtF1OEtYyUe1EQ1k0000</title>\n",
+       "<path fill=\"none\" stroke=\"#696969\" d=\"M221.8896,-73.8681C221.8896,-64.2201 221.8896,-53.1228 221.8896,-43.4439\"/>\n",
+       "<polygon fill=\"#696969\" stroke=\"#696969\" points=\"223.6397,-43.2308 221.8896,-38.2309 220.1397,-43.2309 223.6397,-43.2308\"/>\n",
+       "</g>\n",
+       "<!-- artifact_CMBUzbNNCEDGCKcQ0000 -->\n",
+       "<g id=\"node3\" class=\"node\">\n",
+       "<title>artifact_CMBUzbNNCEDGCKcQ0000</title>\n",
+       "<path fill=\"#f0fff0\" stroke=\"#065f46\" d=\"M423.7393,-196C423.7393,-196 248.04,-196 248.04,-196 242.04,-196 236.04,-190 236.04,-184 236.04,-184 236.04,-170 236.04,-170 236.04,-164 242.04,-158 248.04,-158 248.04,-158 423.7393,-158 423.7393,-158 429.7393,-158 435.7393,-164 435.7393,-170 435.7393,-170 435.7393,-184 435.7393,-184 435.7393,-190 429.7393,-196 423.7393,-196\"/>\n",
+       "<text text-anchor=\"start\" x=\"243.9648\" y=\"-185\" font-family=\"Helvetica,sans-Serif\" font-size=\"10.00\" fill=\"#000000\">📄 PAS offsets file, Neumann et al., 2020</text>\n",
+       "<text text-anchor=\"start\" x=\"260.1694\" y=\"-175\" font-family=\"Monospace\" font-size=\"10.00\" fill=\"#c0c0c0\">uid=CMBUzbNNCEDGCKcQ0000</text>\n",
+       "<text text-anchor=\"start\" x=\"310.7383\" y=\"-165\" font-family=\"Monospace\" font-size=\"10.00\" fill=\"#c0c0c0\">suffix=.json</text>\n",
+       "</g>\n",
+       "<!-- artifact_CMBUzbNNCEDGCKcQ0000&#45;&gt;run_DZlFDV3T7syiFOXMkcHn -->\n",
+       "<g id=\"edge2\" class=\"edge\">\n",
+       "<title>artifact_CMBUzbNNCEDGCKcQ0000&#45;&gt;run_DZlFDV3T7syiFOXMkcHn</title>\n",
+       "<path fill=\"none\" stroke=\"#696969\" d=\"M308.2934,-157.8763C294.0785,-148.0256 276.5038,-135.8466 260.9238,-125.05\"/>\n",
+       "<polygon fill=\"#696969\" stroke=\"#696969\" points=\"261.6933,-123.4541 256.5868,-122.0445 259.6997,-126.3309 261.6933,-123.4541\"/>\n",
+       "</g>\n",
+       "<!-- run_xt2ErUgo7KKqUOOAnVad -->\n",
+       "<g id=\"node5\" class=\"node\">\n",
+       "<title>run_xt2ErUgo7KKqUOOAnVad</title>\n",
+       "<path fill=\"#dcdcdc\" stroke=\"#065f46\" d=\"M943.3699,-280C943.3699,-280 814.4094,-280 814.4094,-280 808.4094,-280 802.4094,-274 802.4094,-268 802.4094,-268 802.4094,-244 802.4094,-244 802.4094,-238 808.4094,-232 814.4094,-232 814.4094,-232 943.3699,-232 943.3699,-232 949.3699,-232 955.3699,-238 955.3699,-244 955.3699,-244 955.3699,-268 955.3699,-268 955.3699,-274 949.3699,-280 943.3699,-280\"/>\n",
+       "<text text-anchor=\"start\" x=\"852.1919\" y=\"-269\" font-family=\"Helvetica,sans-Serif\" font-size=\"10.00\" fill=\"#000000\">📔 Vitessce</text>\n",
+       "<text text-anchor=\"start\" x=\"820.6621\" y=\"-259\" font-family=\"Monospace\" font-size=\"10.00\" fill=\"#c0c0c0\">uid=XmcumVqvKZd30002</text>\n",
+       "<text text-anchor=\"start\" x=\"811.6265\" y=\"-249\" font-family=\"Monospace\" font-size=\"10.00\" fill=\"#c0c0c0\">type=notebook, user=mkeller7</text>\n",
+       "<text text-anchor=\"start\" x=\"810.6499\" y=\"-239\" font-family=\"Monospace\" font-size=\"10.00\" fill=\"#c0c0c0\">run=2024&#45;12&#45;04 16:00:56 UTC</text>\n",
+       "</g>\n",
+       "<!-- run_xt2ErUgo7KKqUOOAnVad&#45;&gt;artifact_0I5aMNdh2UrECtFX0000 -->\n",
+       "<g id=\"edge5\" class=\"edge\">\n",
+       "<title>run_xt2ErUgo7KKqUOOAnVad&#45;&gt;artifact_0I5aMNdh2UrECtFX0000</title>\n",
+       "<path fill=\"none\" stroke=\"#696969\" d=\"M802.42,-250.6543C680.4368,-241.7467 434.3971,-222.2233 226.8896,-196 225.5837,-195.835 224.27,-195.6664 222.9498,-195.4947\"/>\n",
+       "<polygon fill=\"#696969\" stroke=\"#696969\" points=\"223.0139,-193.738 217.8275,-194.8169 222.5547,-197.2078 223.0139,-193.738\"/>\n",
+       "</g>\n",
+       "<!-- run_xt2ErUgo7KKqUOOAnVad&#45;&gt;artifact_CMBUzbNNCEDGCKcQ0000 -->\n",
+       "<g id=\"edge6\" class=\"edge\">\n",
+       "<title>run_xt2ErUgo7KKqUOOAnVad&#45;&gt;artifact_CMBUzbNNCEDGCKcQ0000</title>\n",
+       "<path fill=\"none\" stroke=\"#696969\" d=\"M802.3324,-246.2445C715.529,-234.9909 569.8302,-215.5196 444.8896,-196 443.6027,-195.7989 442.3074,-195.5952 441.0051,-195.389\"/>\n",
+       "<polygon fill=\"#696969\" stroke=\"#696969\" points=\"441.1638,-193.6423 435.9505,-194.5826 440.6123,-197.0986 441.1638,-193.6423\"/>\n",
+       "</g>\n",
+       "<!-- artifact_nelDyBfwvEIIAKcC0000 -->\n",
+       "<g id=\"node6\" class=\"node\">\n",
+       "<title>artifact_nelDyBfwvEIIAKcC0000</title>\n",
+       "<path fill=\"#f0fff0\" stroke=\"#065f46\" d=\"M599.6593,-196C599.6593,-196 466.1199,-196 466.1199,-196 460.1199,-196 454.1199,-190 454.1199,-184 454.1199,-184 454.1199,-170 454.1199,-170 454.1199,-164 460.1199,-158 466.1199,-158 466.1199,-158 599.6593,-158 599.6593,-158 605.6593,-158 611.6593,-164 611.6593,-170 611.6593,-170 611.6593,-184 611.6593,-184 611.6593,-190 605.6593,-196 599.6593,-196\"/>\n",
+       "<text text-anchor=\"start\" x=\"462.0049\" y=\"-185\" font-family=\"Helvetica,sans-Serif\" font-size=\"10.00\" fill=\"#000000\">📄 Visium SpatialData Example</text>\n",
+       "<text text-anchor=\"start\" x=\"469.6621\" y=\"-175\" font-family=\"Monospace\" font-size=\"10.00\" fill=\"#c0c0c0\">uid=nelDyBfwvEIIAKcC0000</text>\n",
+       "<text text-anchor=\"start\" x=\"508.2998\" y=\"-165\" font-family=\"Monospace\" font-size=\"10.00\" fill=\"#c0c0c0\">suffix=.zarr</text>\n",
+       "</g>\n",
+       "<!-- run_xt2ErUgo7KKqUOOAnVad&#45;&gt;artifact_nelDyBfwvEIIAKcC0000 -->\n",
+       "<g id=\"edge4\" class=\"edge\">\n",
+       "<title>run_xt2ErUgo7KKqUOOAnVad&#45;&gt;artifact_nelDyBfwvEIIAKcC0000</title>\n",
+       "<path fill=\"none\" stroke=\"#696969\" d=\"M802.5301,-238.5653C747.5704,-226.0167 673.4515,-209.0936 616.8314,-196.1659\"/>\n",
+       "<polygon fill=\"#696969\" stroke=\"#696969\" points=\"617.0178,-194.4135 611.7537,-195.0065 616.2387,-197.8257 617.0178,-194.4135\"/>\n",
+       "</g>\n",
+       "<!-- artifact_1g3a41z0hggWNBrk0000 -->\n",
+       "<g id=\"node7\" class=\"node\">\n",
+       "<title>artifact_1g3a41z0hggWNBrk0000</title>\n",
+       "<path fill=\"#f0fff0\" stroke=\"#065f46\" d=\"M829.7852,-196C829.7852,-196 641.9941,-196 641.9941,-196 635.9941,-196 629.9941,-190 629.9941,-184 629.9941,-184 629.9941,-170 629.9941,-170 629.9941,-164 635.9941,-158 641.9941,-158 641.9941,-158 829.7852,-158 829.7852,-158 835.7852,-158 841.7852,-164 841.7852,-170 841.7852,-170 841.7852,-184 841.7852,-184 841.7852,-190 835.7852,-196 829.7852,-196\"/>\n",
+       "<text text-anchor=\"start\" x=\"637.9419\" y=\"-185\" font-family=\"Helvetica,sans-Serif\" font-size=\"10.00\" fill=\"#000000\">📄 Habib et al., 2017 Nature Methods, h5ad</text>\n",
+       "<text text-anchor=\"start\" x=\"669.0366\" y=\"-175\" font-family=\"Monospace\" font-size=\"10.00\" fill=\"#c0c0c0\">uid=1g3a41z0hggWNBrk0000</text>\n",
+       "<text text-anchor=\"start\" x=\"708.7876\" y=\"-165\" font-family=\"Monospace\" font-size=\"10.00\" fill=\"#c0c0c0\">suffix=.h5ad</text>\n",
+       "</g>\n",
+       "<!-- run_xt2ErUgo7KKqUOOAnVad&#45;&gt;artifact_1g3a41z0hggWNBrk0000 -->\n",
+       "<g id=\"edge7\" class=\"edge\">\n",
+       "<title>run_xt2ErUgo7KKqUOOAnVad&#45;&gt;artifact_1g3a41z0hggWNBrk0000</title>\n",
+       "<path fill=\"none\" stroke=\"#696969\" d=\"M835.2079,-231.8681C816.1267,-221.3267 793.9139,-209.0553 775.3397,-198.7941\"/>\n",
+       "<polygon fill=\"#696969\" stroke=\"#696969\" points=\"775.9228,-197.1169 770.6999,-196.2309 774.2303,-200.1805 775.9228,-197.1169\"/>\n",
+       "</g>\n",
+       "<!-- artifact_O7CTVi6XjnfsceQ20000 -->\n",
+       "<g id=\"node8\" class=\"node\">\n",
+       "<title>artifact_O7CTVi6XjnfsceQ20000</title>\n",
+       "<path fill=\"#f0fff0\" stroke=\"#065f46\" d=\"M1172.088,-196C1172.088,-196 871.6913,-196 871.6913,-196 865.6913,-196 859.6913,-190 859.6913,-184 859.6913,-184 859.6913,-170 859.6913,-170 859.6913,-164 865.6913,-158 871.6913,-158 871.6913,-158 1172.088,-158 1172.088,-158 1178.088,-158 1184.088,-164 1184.088,-170 1184.088,-170 1184.088,-184 1184.088,-184 1184.088,-190 1178.088,-196 1172.088,-196\"/>\n",
+       "<text text-anchor=\"start\" x=\"867.5405\" y=\"-185\" font-family=\"Helvetica,sans-Serif\" font-size=\"10.00\" fill=\"#000000\">📄 Reference JSON for H5AD file, Habib et al., 2017 Nature Methods</text>\n",
+       "<text text-anchor=\"start\" x=\"957.6343\" y=\"-175\" font-family=\"Monospace\" font-size=\"10.00\" fill=\"#c0c0c0\">uid=O7CTVi6XjnfsceQ20000</text>\n",
+       "<text text-anchor=\"start\" x=\"996.7383\" y=\"-165\" font-family=\"Monospace\" font-size=\"10.00\" fill=\"#c0c0c0\">suffix=.json</text>\n",
+       "</g>\n",
+       "<!-- run_xt2ErUgo7KKqUOOAnVad&#45;&gt;artifact_O7CTVi6XjnfsceQ20000 -->\n",
+       "<g id=\"edge8\" class=\"edge\">\n",
+       "<title>run_xt2ErUgo7KKqUOOAnVad&#45;&gt;artifact_O7CTVi6XjnfsceQ20000</title>\n",
+       "<path fill=\"none\" stroke=\"#696969\" d=\"M922.5714,-231.8681C941.6526,-221.3267 963.8654,-209.0553 982.4396,-198.7941\"/>\n",
+       "<polygon fill=\"#696969\" stroke=\"#696969\" points=\"983.549,-200.1805 987.0794,-196.2309 981.8565,-197.1169 983.549,-200.1805\"/>\n",
+       "</g>\n",
+       "<!-- artifact_kWwG45Hr26KZUW3g0004 -->\n",
+       "<g id=\"node9\" class=\"node\">\n",
+       "<title>artifact_kWwG45Hr26KZUW3g0004</title>\n",
+       "<path fill=\"#f0fff0\" stroke=\"#065f46\" d=\"M1397.2608,-196C1397.2608,-196 1214.5185,-196 1214.5185,-196 1208.5185,-196 1202.5185,-190 1202.5185,-184 1202.5185,-184 1202.5185,-170 1202.5185,-170 1202.5185,-164 1208.5185,-158 1214.5185,-158 1214.5185,-158 1397.2608,-158 1397.2608,-158 1403.2608,-158 1409.2608,-164 1409.2608,-170 1409.2608,-170 1409.2608,-184 1409.2608,-184 1409.2608,-190 1403.2608,-196 1397.2608,-196\"/>\n",
+       "<text text-anchor=\"start\" x=\"1210.4541\" y=\"-185\" font-family=\"Helvetica,sans-Serif\" font-size=\"10.00\" fill=\"#000000\">📄 Habib et al., 2017 Nature Methods, zarr</text>\n",
+       "<text text-anchor=\"start\" x=\"1233.7754\" y=\"-175\" font-family=\"Monospace\" font-size=\"10.00\" fill=\"#c0c0c0\">uid=kWwG45Hr26KZUW3g0004</text>\n",
+       "<text text-anchor=\"start\" x=\"1261.8369\" y=\"-165\" font-family=\"Monospace\" font-size=\"10.00\" fill=\"#c0c0c0\">suffix=.anndata.zarr</text>\n",
+       "</g>\n",
+       "<!-- run_xt2ErUgo7KKqUOOAnVad&#45;&gt;artifact_kWwG45Hr26KZUW3g0004 -->\n",
+       "<g id=\"edge9\" class=\"edge\">\n",
+       "<title>run_xt2ErUgo7KKqUOOAnVad&#45;&gt;artifact_kWwG45Hr26KZUW3g0004</title>\n",
+       "<path fill=\"none\" stroke=\"#696969\" d=\"M955.2287,-241.8764C1022.8309,-229.3692 1122.2496,-210.9756 1197.9798,-196.9646\"/>\n",
+       "<polygon fill=\"#696969\" stroke=\"#696969\" points=\"1198.335,-198.6787 1202.9331,-196.0482 1197.6982,-195.2371 1198.335,-198.6787\"/>\n",
+       "</g>\n",
+       "<!-- collection_obXokdzOnSH2tytJ0000 -->\n",
+       "<g id=\"node10\" class=\"node\">\n",
+       "<title>collection_obXokdzOnSH2tytJ0000</title>\n",
+       "<path fill=\"#f0fff0\" stroke=\"#065f46\" d=\"M1590.8379,-196C1590.8379,-196 1438.9414,-196 1438.9414,-196 1432.9414,-196 1426.9414,-190 1426.9414,-184 1426.9414,-184 1426.9414,-170 1426.9414,-170 1426.9414,-164 1432.9414,-158 1438.9414,-158 1438.9414,-158 1590.8379,-158 1590.8379,-158 1596.8379,-158 1602.8379,-164 1602.8379,-170 1602.8379,-170 1602.8379,-184 1602.8379,-184 1602.8379,-190 1596.8379,-196 1590.8379,-196\"/>\n",
+       "<text text-anchor=\"start\" x=\"1434.9155\" y=\"-185\" font-family=\"Helvetica,sans-Serif\" font-size=\"10.00\" fill=\"#000000\">🍱 View Habib17 (h5ad) in Vitessce</text>\n",
+       "<text text-anchor=\"start\" x=\"1450.5415\" y=\"-175\" font-family=\"Monospace\" font-size=\"10.00\" fill=\"#c0c0c0\">uid=obXokdzOnSH2tytJ0000</text>\n",
+       "<text text-anchor=\"start\" x=\"1483.8984\" y=\"-165\" font-family=\"Monospace\" font-size=\"10.00\" fill=\"#c0c0c0\">version=None</text>\n",
+       "</g>\n",
+       "<!-- run_xt2ErUgo7KKqUOOAnVad&#45;&gt;collection_obXokdzOnSH2tytJ0000 -->\n",
+       "<g id=\"edge10\" class=\"edge\">\n",
+       "<title>run_xt2ErUgo7KKqUOOAnVad&#45;&gt;collection_obXokdzOnSH2tytJ0000</title>\n",
+       "<path fill=\"none\" stroke=\"#696969\" d=\"M955.4681,-249.4818C1060.2052,-240.11 1253.8595,-221.1506 1417.8896,-196 1419.1883,-195.8009 1420.496,-195.5967 1421.8112,-195.3879\"/>\n",
+       "<polygon fill=\"#696969\" stroke=\"#696969\" points=\"1422.261,-197.0879 1426.9167,-194.5607 1421.7012,-193.6329 1422.261,-197.0879\"/>\n",
+       "</g>\n",
+       "<!-- collection_HqfzZmkfYOy20ZNN0000 -->\n",
+       "<g id=\"node11\" class=\"node\">\n",
+       "<title>collection_HqfzZmkfYOy20ZNN0000</title>\n",
+       "<path fill=\"#f0fff0\" stroke=\"#065f46\" d=\"M1885.2336,-196C1885.2336,-196 1632.5457,-196 1632.5457,-196 1626.5457,-196 1620.5457,-190 1620.5457,-184 1620.5457,-184 1620.5457,-170 1620.5457,-170 1620.5457,-164 1626.5457,-158 1632.5457,-158 1632.5457,-158 1885.2336,-158 1885.2336,-158 1891.2336,-158 1897.2336,-164 1897.2336,-170 1897.2336,-170 1897.2336,-184 1897.2336,-184 1897.2336,-190 1891.2336,-196 1885.2336,-196\"/>\n",
+       "<text text-anchor=\"start\" x=\"1628.7178\" y=\"-185\" font-family=\"Helvetica,sans-Serif\" font-size=\"10.00\" fill=\"#000000\">🍱 View PAS OME&#45;TIFF, Neumann et al., 2020 in Vitessce</text>\n",
+       "<text text-anchor=\"start\" x=\"1691.2236\" y=\"-175\" font-family=\"Monospace\" font-size=\"10.00\" fill=\"#c0c0c0\">uid=HqfzZmkfYOy20ZNN0000</text>\n",
+       "<text text-anchor=\"start\" x=\"1727.8984\" y=\"-165\" font-family=\"Monospace\" font-size=\"10.00\" fill=\"#c0c0c0\">version=None</text>\n",
+       "</g>\n",
+       "<!-- run_xt2ErUgo7KKqUOOAnVad&#45;&gt;collection_HqfzZmkfYOy20ZNN0000 -->\n",
+       "<g id=\"edge11\" class=\"edge\">\n",
+       "<title>run_xt2ErUgo7KKqUOOAnVad&#45;&gt;collection_HqfzZmkfYOy20ZNN0000</title>\n",
+       "<path fill=\"none\" stroke=\"#696969\" d=\"M955.2406,-250.934C1088.6279,-241.8192 1372.695,-221.2338 1611.8896,-196 1613.0333,-195.8794 1614.1817,-195.7571 1615.3345,-195.6334\"/>\n",
+       "<polygon fill=\"#696969\" stroke=\"#696969\" points=\"1615.6336,-197.3613 1620.4155,-195.0818 1615.2558,-193.8818 1615.6336,-197.3613\"/>\n",
+       "</g>\n",
+       "</g>\n",
+       "</svg>\n"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "ome_tiff_vc_artifact.view_lineage()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    ":::{note}\n",
+    "\n",
+    "After running `save_vitessce_config`, a Vitessce button will appear next to the dataset in the [Artifacts](https://lamin.ai/vitessce/examples/artifacts) page of the web interface.\n",
+    "\n",
+    "If your `VitessceConfig` object references data from multiple artifacts, the Vitessce button will appear next to a `Collection` that groups these artifacts (on the [Collections](https://lamin.ai/vitessce/examples/collections) tab of the Artifacts page).\n",
+    "In the case of OME-TIFF, the presence of the corresponding offsets JSON file will result in the creation of a Collection.\n",
+    "\n",
+    ":::"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Visualize an image (OME-Zarr format)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Retrieve an OME-Zarr (also known as OME-NGFF) formatted image. We could download an unzip such an image, but in downloading the SpatialData object above, we already have access to a valid OME-Zarr image locally."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 40,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "ome_zarr_filepath = Path(sdata_zarr_filepath) / \"images\" / \"CytAssist_FFPE_Human_Breast_Cancer_full_image\""
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Save the dataset"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Save the `.ome.zarr` DirectoryStore as a LaminDB Artifact."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 41,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\u001b[92m→\u001b[0m returning existing artifact with same hash: Artifact(uid='toCvpsqAiH3XcAvT0000', is_latest=True, key='vitessce_examples/visium.ome.zarr', description='Visium OME-Zarr Example', suffix='', type='dataset', size=1400251840, hash='UtsNOkk05EFL34hgUabEwg', n_objects=8809, _hash_type='md5-d', visibility=1, _key_is_virtual=True, storage_id=1, transform_id=16, run_id=73, created_by_id=2, created_at=2024-12-04 14:38:29 UTC)\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "Artifact(uid='toCvpsqAiH3XcAvT0000', is_latest=True, key='vitessce_examples/visium.ome.zarr', description='Visium OME-Zarr Example', suffix='', type='dataset', size=1400251840, hash='UtsNOkk05EFL34hgUabEwg', n_objects=8809, _hash_type='md5-d', visibility=1, _key_is_virtual=True, storage_id=1, transform_id=17, run_id=79, created_by_id=2, created_at=2024-12-04 14:38:29 UTC)"
+      ]
+     },
+     "execution_count": 41,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "ome_zarr_artifact = ln.Artifact(\n",
+    "    ome_zarr_filepath,\n",
+    "    key=\"vitessce_examples/visium.ome.zarr\",\n",
+    "    description=\"Visium OME-Zarr Example\",\n",
+    "    type=\"dataset\",\n",
+    ")\n",
+    "ome_zarr_artifact.save()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Save a VitessceConfig object"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "You can create a dashboard for one or several datasets by using Vitessce's component API.\n",
+    "Here, we use the [ImageOmeZarrWrapper](https://python-docs.vitessce.io/api_data.html#vitessce.wrappers.ImageOmeZarrWrapper) class to specify an OME-Zarr file to load for visualization."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 42,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "vc = vit.VitessceConfig(\n",
+    "    schema_version=\"1.0.17\",\n",
+    "    description=ome_zarr_artifact.description\n",
+    ")\n",
+    "dataset_uid = \"ome_zarr_image\"\n",
+    "dataset = vc.add_dataset(\"Image\", uid=dataset_uid).add_object(\n",
+    "    vit.ImageOmeZarrWrapper(\n",
+    "        img_artifact=ome_zarr_artifact,\n",
+    "    )\n",
+    ")\n",
+    "spatial = vc.add_view(\"spatialBeta\", dataset=dataset)\n",
+    "layer_controller = vc.add_view(\"layerControllerBeta\", dataset=dataset)\n",
+    "vc.link_views_by_dict([spatial, layer_controller], {\n",
+    "    \"imageLayer\": vit.CoordinationLevel([{\n",
+    "        \"photometricInterpretation\": \"RGB\",\n",
+    "    }]),\n",
+    "}, scope_prefix=vit.get_initial_coordination_scope_prefix(dataset_uid, \"image\"))\n",
+    "vc.layout(spatial | layer_controller);"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Save the `VitessceConfig` object."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 43,
+   "metadata": {
+    "tags": [
+     "hide-output"
+    ]
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\u001b[92m→\u001b[0m VitessceConfig references these artifacts:\n",
+      "Artifact(uid='toCvpsqAiH3XcAvT0000', is_latest=True, key='vitessce_examples/visium.ome.zarr', description='Visium OME-Zarr Example', suffix='', type='dataset', size=1400251840, hash='UtsNOkk05EFL34hgUabEwg', n_objects=8809, _hash_type='md5-d', visibility=1, _key_is_virtual=True, storage_id=1, transform_id=17, run_id=79, created_by_id=2, created_at=2024-12-04 14:38:29 UTC)\n",
+      "\u001b[92m→\u001b[0m returning existing artifact with same hash: Artifact(uid='cjvX6EFrdSwsxOQl0000', is_latest=True, description='View Visium OME-Zarr Example in Vitessce', suffix='.vitessce.json', size=1240, hash='PiQa8hZ7nphs4FoTdhOwxg', _hash_type='md5', visibility=1, _key_is_virtual=True, storage_id=1, transform_id=15, run_id=78, created_by_id=2, created_at=2024-12-04 15:53:20 UTC)\n",
+      "\u001b[92m→\u001b[0m VitessceConfig: https://lamin.ai/vitessce/examples/artifact/cjvX6EFrdSwsxOQl0000\n",
+      "\u001b[92m→\u001b[0m Dataset: https://lamin.ai/vitessce/examples/artifact/toCvpsqAiH3XcAvT0000\n"
+     ]
+    }
+   ],
+   "source": [
+    "ome_zarr_vc_artifact = ln.integrations.save_vitessce_config(\n",
+    "    vc, description=\"View Visium OME-Zarr Example in Vitessce\",\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 44,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "image/svg+xml": [
+       "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"no\"?>\n",
+       "<!DOCTYPE svg PUBLIC \"-//W3C//DTD SVG 1.1//EN\"\n",
+       " \"http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd\">\n",
+       "<!-- Generated by graphviz version 2.40.1 (20161225.0304)\n",
+       " -->\n",
+       "<!-- Title: artifact_cjvX6EFrdSwsxOQl0000 Pages: 1 -->\n",
+       "<svg width=\"2111pt\" height=\"288pt\"\n",
+       " viewBox=\"0.00 0.00 2111.04 288.00\" xmlns=\"http://www.w3.org/2000/svg\" xmlns:xlink=\"http://www.w3.org/1999/xlink\">\n",
+       "<g id=\"graph0\" class=\"graph\" transform=\"scale(1 1) rotate(0) translate(4 284)\">\n",
+       "<title>artifact_cjvX6EFrdSwsxOQl0000</title>\n",
+       "<polygon fill=\"#ffffff\" stroke=\"transparent\" points=\"-4,4 -4,-284 2107.0435,-284 2107.0435,4 -4,4\"/>\n",
+       "<!-- artifact_toCvpsqAiH3XcAvT0000 -->\n",
+       "<g id=\"node1\" class=\"node\">\n",
+       "<title>artifact_toCvpsqAiH3XcAvT0000</title>\n",
+       "<path fill=\"#f0fff0\" stroke=\"#065f46\" d=\"M175.8812,-196C175.8812,-196 49.862,-196 49.862,-196 43.862,-196 37.862,-190 37.862,-184 37.862,-184 37.862,-170 37.862,-170 37.862,-164 43.862,-158 49.862,-158 49.862,-158 175.8812,-158 175.8812,-158 181.8812,-158 187.8812,-164 187.8812,-170 187.8812,-170 187.8812,-184 187.8812,-184 187.8812,-190 181.8812,-196 175.8812,-196\"/>\n",
+       "<text text-anchor=\"start\" x=\"45.6172\" y=\"-185\" font-family=\"Helvetica,sans-Serif\" font-size=\"10.00\" fill=\"#000000\">📄 Visium OME&#45;Zarr Example</text>\n",
+       "<text text-anchor=\"start\" x=\"48.3403\" y=\"-175\" font-family=\"Monospace\" font-size=\"10.00\" fill=\"#c0c0c0\">uid=toCvpsqAiH3XcAvT0000</text>\n",
+       "<text text-anchor=\"start\" x=\"98.2817\" y=\"-165\" font-family=\"Monospace\" font-size=\"10.00\" fill=\"#c0c0c0\">suffix=</text>\n",
+       "</g>\n",
+       "<!-- run_VtJZt0vnqrXHjGQU3Jdu -->\n",
+       "<g id=\"node2\" class=\"node\">\n",
+       "<title>run_VtJZt0vnqrXHjGQU3Jdu</title>\n",
+       "<path fill=\"#dcdcdc\" stroke=\"#065f46\" d=\"M177.3518,-122C177.3518,-122 48.3913,-122 48.3913,-122 42.3913,-122 36.3913,-116 36.3913,-110 36.3913,-110 36.3913,-86 36.3913,-86 36.3913,-80 42.3913,-74 48.3913,-74 48.3913,-74 177.3518,-74 177.3518,-74 183.3518,-74 189.3518,-80 189.3518,-86 189.3518,-86 189.3518,-110 189.3518,-110 189.3518,-116 183.3518,-122 177.3518,-122\"/>\n",
+       "<text text-anchor=\"start\" x=\"57.4556\" y=\"-111\" font-family=\"Helvetica,sans-Serif\" font-size=\"10.00\" fill=\"#000000\">🔧 save_vitessce_config</text>\n",
+       "<text text-anchor=\"start\" x=\"58.897\" y=\"-101\" font-family=\"Monospace\" font-size=\"10.00\" fill=\"#c0c0c0\">uid=kup03MJBsIVa0002</text>\n",
+       "<text text-anchor=\"start\" x=\"48.6699\" y=\"-91\" font-family=\"Monospace\" font-size=\"10.00\" fill=\"#c0c0c0\">type=function, user=mkeller7</text>\n",
+       "<text text-anchor=\"start\" x=\"44.6318\" y=\"-81\" font-family=\"Monospace\" font-size=\"10.00\" fill=\"#c0c0c0\">run=2024&#45;12&#45;04 16:01:44 UTC</text>\n",
+       "</g>\n",
+       "<!-- artifact_toCvpsqAiH3XcAvT0000&#45;&gt;run_VtJZt0vnqrXHjGQU3Jdu -->\n",
+       "<g id=\"edge1\" class=\"edge\">\n",
+       "<title>artifact_toCvpsqAiH3XcAvT0000&#45;&gt;run_VtJZt0vnqrXHjGQU3Jdu</title>\n",
+       "<path fill=\"none\" stroke=\"#696969\" d=\"M112.8716,-157.8763C112.8716,-148.6991 112.8716,-137.5013 112.8716,-127.2829\"/>\n",
+       "<polygon fill=\"#696969\" stroke=\"#696969\" points=\"114.6217,-127.0445 112.8716,-122.0445 111.1217,-127.0445 114.6217,-127.0445\"/>\n",
+       "</g>\n",
+       "<!-- artifact_cjvX6EFrdSwsxOQl0000 -->\n",
+       "<g id=\"node3\" class=\"node\">\n",
+       "<title>artifact_cjvX6EFrdSwsxOQl0000</title>\n",
+       "<path fill=\"#10b981\" stroke=\"#065f46\" d=\"M213.6149,-38C213.6149,-38 12.1283,-38 12.1283,-38 6.1283,-38 .1283,-32 .1283,-26 .1283,-26 .1283,-12 .1283,-12 .1283,-6 6.1283,0 12.1283,0 12.1283,0 213.6149,0 213.6149,0 219.6149,0 225.6149,-6 225.6149,-12 225.6149,-12 225.6149,-26 225.6149,-26 225.6149,-32 219.6149,-38 213.6149,-38\"/>\n",
+       "<text text-anchor=\"start\" x=\"8\" y=\"-27\" font-family=\"Helvetica,sans-Serif\" font-size=\"10.00\" fill=\"#000000\">📄 View Visium OME&#45;Zarr Example in Vitessce</text>\n",
+       "<text text-anchor=\"start\" x=\"48.2598\" y=\"-17\" font-family=\"Monospace\" font-size=\"10.00\" fill=\"#c0c0c0\">uid=cjvX6EFrdSwsxOQl0000</text>\n",
+       "<text text-anchor=\"start\" x=\"68.2695\" y=\"-7\" font-family=\"Monospace\" font-size=\"10.00\" fill=\"#c0c0c0\">suffix=.vitessce.json</text>\n",
+       "</g>\n",
+       "<!-- run_VtJZt0vnqrXHjGQU3Jdu&#45;&gt;artifact_cjvX6EFrdSwsxOQl0000 -->\n",
+       "<g id=\"edge2\" class=\"edge\">\n",
+       "<title>run_VtJZt0vnqrXHjGQU3Jdu&#45;&gt;artifact_cjvX6EFrdSwsxOQl0000</title>\n",
+       "<path fill=\"none\" stroke=\"#696969\" d=\"M112.8716,-73.8681C112.8716,-64.2201 112.8716,-53.1228 112.8716,-43.4439\"/>\n",
+       "<polygon fill=\"#696969\" stroke=\"#696969\" points=\"114.6217,-43.2308 112.8716,-38.2309 111.1217,-43.2309 114.6217,-43.2308\"/>\n",
+       "</g>\n",
+       "<!-- run_xt2ErUgo7KKqUOOAnVad -->\n",
+       "<g id=\"node4\" class=\"node\">\n",
+       "<title>run_xt2ErUgo7KKqUOOAnVad</title>\n",
+       "<path fill=\"#dcdcdc\" stroke=\"#065f46\" d=\"M1006.3518,-280C1006.3518,-280 877.3913,-280 877.3913,-280 871.3913,-280 865.3913,-274 865.3913,-268 865.3913,-268 865.3913,-244 865.3913,-244 865.3913,-238 871.3913,-232 877.3913,-232 877.3913,-232 1006.3518,-232 1006.3518,-232 1012.3518,-232 1018.3518,-238 1018.3518,-244 1018.3518,-244 1018.3518,-268 1018.3518,-268 1018.3518,-274 1012.3518,-280 1006.3518,-280\"/>\n",
+       "<text text-anchor=\"start\" x=\"915.1738\" y=\"-269\" font-family=\"Helvetica,sans-Serif\" font-size=\"10.00\" fill=\"#000000\">📔 Vitessce</text>\n",
+       "<text text-anchor=\"start\" x=\"883.644\" y=\"-259\" font-family=\"Monospace\" font-size=\"10.00\" fill=\"#c0c0c0\">uid=XmcumVqvKZd30002</text>\n",
+       "<text text-anchor=\"start\" x=\"874.6084\" y=\"-249\" font-family=\"Monospace\" font-size=\"10.00\" fill=\"#c0c0c0\">type=notebook, user=mkeller7</text>\n",
+       "<text text-anchor=\"start\" x=\"873.6318\" y=\"-239\" font-family=\"Monospace\" font-size=\"10.00\" fill=\"#c0c0c0\">run=2024&#45;12&#45;04 16:00:56 UTC</text>\n",
+       "</g>\n",
+       "<!-- run_xt2ErUgo7KKqUOOAnVad&#45;&gt;artifact_toCvpsqAiH3XcAvT0000 -->\n",
+       "<g id=\"edge6\" class=\"edge\">\n",
+       "<title>run_xt2ErUgo7KKqUOOAnVad&#45;&gt;artifact_toCvpsqAiH3XcAvT0000</title>\n",
+       "<path fill=\"none\" stroke=\"#696969\" d=\"M865.5799,-253.4334C730.2267,-248.0853 439.471,-233.0141 196.8716,-196 195.7307,-195.8259 194.5822,-195.6451 193.4277,-195.458\"/>\n",
+       "<polygon fill=\"#696969\" stroke=\"#696969\" points=\"193.5525,-193.7045 188.3313,-194.5999 192.9713,-197.1559 193.5525,-193.7045\"/>\n",
+       "</g>\n",
+       "<!-- artifact_nelDyBfwvEIIAKcC0000 -->\n",
+       "<g id=\"node5\" class=\"node\">\n",
+       "<title>artifact_nelDyBfwvEIIAKcC0000</title>\n",
+       "<path fill=\"#f0fff0\" stroke=\"#065f46\" d=\"M351.6413,-196C351.6413,-196 218.1019,-196 218.1019,-196 212.1019,-196 206.1019,-190 206.1019,-184 206.1019,-184 206.1019,-170 206.1019,-170 206.1019,-164 212.1019,-158 218.1019,-158 218.1019,-158 351.6413,-158 351.6413,-158 357.6413,-158 363.6413,-164 363.6413,-170 363.6413,-170 363.6413,-184 363.6413,-184 363.6413,-190 357.6413,-196 351.6413,-196\"/>\n",
+       "<text text-anchor=\"start\" x=\"213.9868\" y=\"-185\" font-family=\"Helvetica,sans-Serif\" font-size=\"10.00\" fill=\"#000000\">📄 Visium SpatialData Example</text>\n",
+       "<text text-anchor=\"start\" x=\"221.644\" y=\"-175\" font-family=\"Monospace\" font-size=\"10.00\" fill=\"#c0c0c0\">uid=nelDyBfwvEIIAKcC0000</text>\n",
+       "<text text-anchor=\"start\" x=\"260.2817\" y=\"-165\" font-family=\"Monospace\" font-size=\"10.00\" fill=\"#c0c0c0\">suffix=.zarr</text>\n",
+       "</g>\n",
+       "<!-- run_xt2ErUgo7KKqUOOAnVad&#45;&gt;artifact_nelDyBfwvEIIAKcC0000 -->\n",
+       "<g id=\"edge3\" class=\"edge\">\n",
+       "<title>run_xt2ErUgo7KKqUOOAnVad&#45;&gt;artifact_nelDyBfwvEIIAKcC0000</title>\n",
+       "<path fill=\"none\" stroke=\"#696969\" d=\"M865.5983,-250.5795C756.0921,-242.2034 548.1927,-224.0868 372.8716,-196 371.5887,-195.7945 370.2964,-195.5823 368.9965,-195.364\"/>\n",
+       "<polygon fill=\"#696969\" stroke=\"#696969\" points=\"369.1745,-193.619 363.9498,-194.4937 368.5796,-197.0681 369.1745,-193.619\"/>\n",
+       "</g>\n",
+       "<!-- artifact_0I5aMNdh2UrECtFX0000 -->\n",
+       "<g id=\"node6\" class=\"node\">\n",
+       "<title>artifact_0I5aMNdh2UrECtFX0000</title>\n",
+       "<path fill=\"#f0fff0\" stroke=\"#065f46\" d=\"M587.651,-196C587.651,-196 394.0922,-196 394.0922,-196 388.0922,-196 382.0922,-190 382.0922,-184 382.0922,-184 382.0922,-170 382.0922,-170 382.0922,-164 388.0922,-158 394.0922,-158 394.0922,-158 587.651,-158 587.651,-158 593.651,-158 599.651,-164 599.651,-170 599.651,-170 599.651,-184 599.651,-184 599.651,-190 593.651,-196 587.651,-196\"/>\n",
+       "<text text-anchor=\"start\" x=\"389.9819\" y=\"-185\" font-family=\"Helvetica,sans-Serif\" font-size=\"10.00\" fill=\"#000000\">📄 PAS OME&#45;TIFF file, Neumann et al., 2020</text>\n",
+       "<text text-anchor=\"start\" x=\"424.3066\" y=\"-175\" font-family=\"Monospace\" font-size=\"10.00\" fill=\"#c0c0c0\">uid=0I5aMNdh2UrECtFX0000</text>\n",
+       "<text text-anchor=\"start\" x=\"471.0034\" y=\"-165\" font-family=\"Monospace\" font-size=\"10.00\" fill=\"#c0c0c0\">suffix=.tif</text>\n",
+       "</g>\n",
+       "<!-- run_xt2ErUgo7KKqUOOAnVad&#45;&gt;artifact_0I5aMNdh2UrECtFX0000 -->\n",
+       "<g id=\"edge4\" class=\"edge\">\n",
+       "<title>run_xt2ErUgo7KKqUOOAnVad&#45;&gt;artifact_0I5aMNdh2UrECtFX0000</title>\n",
+       "<path fill=\"none\" stroke=\"#696969\" d=\"M865.6207,-242.6434C794.2217,-230.1367 686.5908,-211.2834 604.9673,-196.9857\"/>\n",
+       "<polygon fill=\"#696969\" stroke=\"#696969\" points=\"604.8562,-195.1897 599.6292,-196.0507 604.2522,-198.6372 604.8562,-195.1897\"/>\n",
+       "</g>\n",
+       "<!-- artifact_CMBUzbNNCEDGCKcQ0000 -->\n",
+       "<g id=\"node7\" class=\"node\">\n",
+       "<title>artifact_CMBUzbNNCEDGCKcQ0000</title>\n",
+       "<path fill=\"#f0fff0\" stroke=\"#065f46\" d=\"M805.7212,-196C805.7212,-196 630.0219,-196 630.0219,-196 624.0219,-196 618.0219,-190 618.0219,-184 618.0219,-184 618.0219,-170 618.0219,-170 618.0219,-164 624.0219,-158 630.0219,-158 630.0219,-158 805.7212,-158 805.7212,-158 811.7212,-158 817.7212,-164 817.7212,-170 817.7212,-170 817.7212,-184 817.7212,-184 817.7212,-190 811.7212,-196 805.7212,-196\"/>\n",
+       "<text text-anchor=\"start\" x=\"625.9468\" y=\"-185\" font-family=\"Helvetica,sans-Serif\" font-size=\"10.00\" fill=\"#000000\">📄 PAS offsets file, Neumann et al., 2020</text>\n",
+       "<text text-anchor=\"start\" x=\"642.1514\" y=\"-175\" font-family=\"Monospace\" font-size=\"10.00\" fill=\"#c0c0c0\">uid=CMBUzbNNCEDGCKcQ0000</text>\n",
+       "<text text-anchor=\"start\" x=\"692.7202\" y=\"-165\" font-family=\"Monospace\" font-size=\"10.00\" fill=\"#c0c0c0\">suffix=.json</text>\n",
+       "</g>\n",
+       "<!-- run_xt2ErUgo7KKqUOOAnVad&#45;&gt;artifact_CMBUzbNNCEDGCKcQ0000 -->\n",
+       "<g id=\"edge5\" class=\"edge\">\n",
+       "<title>run_xt2ErUgo7KKqUOOAnVad&#45;&gt;artifact_CMBUzbNNCEDGCKcQ0000</title>\n",
+       "<path fill=\"none\" stroke=\"#696969\" d=\"M873.7519,-231.9756C842.7185,-221.0308 806.3463,-208.2031 776.5449,-197.6928\"/>\n",
+       "<polygon fill=\"#696969\" stroke=\"#696969\" points=\"777.1177,-196.0392 771.8202,-196.0265 775.9535,-199.34 777.1177,-196.0392\"/>\n",
+       "</g>\n",
+       "<!-- artifact_1g3a41z0hggWNBrk0000 -->\n",
+       "<g id=\"node8\" class=\"node\">\n",
+       "<title>artifact_1g3a41z0hggWNBrk0000</title>\n",
+       "<path fill=\"#f0fff0\" stroke=\"#065f46\" d=\"M1035.7671,-196C1035.7671,-196 847.976,-196 847.976,-196 841.976,-196 835.976,-190 835.976,-184 835.976,-184 835.976,-170 835.976,-170 835.976,-164 841.976,-158 847.976,-158 847.976,-158 1035.7671,-158 1035.7671,-158 1041.7671,-158 1047.7671,-164 1047.7671,-170 1047.7671,-170 1047.7671,-184 1047.7671,-184 1047.7671,-190 1041.7671,-196 1035.7671,-196\"/>\n",
+       "<text text-anchor=\"start\" x=\"843.9238\" y=\"-185\" font-family=\"Helvetica,sans-Serif\" font-size=\"10.00\" fill=\"#000000\">📄 Habib et al., 2017 Nature Methods, h5ad</text>\n",
+       "<text text-anchor=\"start\" x=\"875.0186\" y=\"-175\" font-family=\"Monospace\" font-size=\"10.00\" fill=\"#c0c0c0\">uid=1g3a41z0hggWNBrk0000</text>\n",
+       "<text text-anchor=\"start\" x=\"914.7695\" y=\"-165\" font-family=\"Monospace\" font-size=\"10.00\" fill=\"#c0c0c0\">suffix=.h5ad</text>\n",
+       "</g>\n",
+       "<!-- run_xt2ErUgo7KKqUOOAnVad&#45;&gt;artifact_1g3a41z0hggWNBrk0000 -->\n",
+       "<g id=\"edge7\" class=\"edge\">\n",
+       "<title>run_xt2ErUgo7KKqUOOAnVad&#45;&gt;artifact_1g3a41z0hggWNBrk0000</title>\n",
+       "<path fill=\"none\" stroke=\"#696969\" d=\"M941.8716,-231.8681C941.8716,-222.2201 941.8716,-211.1228 941.8716,-201.4439\"/>\n",
+       "<polygon fill=\"#696969\" stroke=\"#696969\" points=\"943.6217,-201.2308 941.8716,-196.2309 940.1217,-201.2309 943.6217,-201.2308\"/>\n",
+       "</g>\n",
+       "<!-- artifact_O7CTVi6XjnfsceQ20000 -->\n",
+       "<g id=\"node9\" class=\"node\">\n",
+       "<title>artifact_O7CTVi6XjnfsceQ20000</title>\n",
+       "<path fill=\"#f0fff0\" stroke=\"#065f46\" d=\"M1378.07,-196C1378.07,-196 1077.6732,-196 1077.6732,-196 1071.6732,-196 1065.6732,-190 1065.6732,-184 1065.6732,-184 1065.6732,-170 1065.6732,-170 1065.6732,-164 1071.6732,-158 1077.6732,-158 1077.6732,-158 1378.07,-158 1378.07,-158 1384.07,-158 1390.07,-164 1390.07,-170 1390.07,-170 1390.07,-184 1390.07,-184 1390.07,-190 1384.07,-196 1378.07,-196\"/>\n",
+       "<text text-anchor=\"start\" x=\"1073.5225\" y=\"-185\" font-family=\"Helvetica,sans-Serif\" font-size=\"10.00\" fill=\"#000000\">📄 Reference JSON for H5AD file, Habib et al., 2017 Nature Methods</text>\n",
+       "<text text-anchor=\"start\" x=\"1163.6162\" y=\"-175\" font-family=\"Monospace\" font-size=\"10.00\" fill=\"#c0c0c0\">uid=O7CTVi6XjnfsceQ20000</text>\n",
+       "<text text-anchor=\"start\" x=\"1202.7202\" y=\"-165\" font-family=\"Monospace\" font-size=\"10.00\" fill=\"#c0c0c0\">suffix=.json</text>\n",
+       "</g>\n",
+       "<!-- run_xt2ErUgo7KKqUOOAnVad&#45;&gt;artifact_O7CTVi6XjnfsceQ20000 -->\n",
+       "<g id=\"edge8\" class=\"edge\">\n",
+       "<title>run_xt2ErUgo7KKqUOOAnVad&#45;&gt;artifact_O7CTVi6XjnfsceQ20000</title>\n",
+       "<path fill=\"none\" stroke=\"#696969\" d=\"M1018.1386,-234.9332C1060.1176,-223.3376 1111.9871,-209.0101 1153.6399,-197.5046\"/>\n",
+       "<polygon fill=\"#696969\" stroke=\"#696969\" points=\"1154.3139,-199.134 1158.6675,-196.1158 1153.382,-195.7603 1154.3139,-199.134\"/>\n",
+       "</g>\n",
+       "<!-- artifact_kWwG45Hr26KZUW3g0004 -->\n",
+       "<g id=\"node10\" class=\"node\">\n",
+       "<title>artifact_kWwG45Hr26KZUW3g0004</title>\n",
+       "<path fill=\"#f0fff0\" stroke=\"#065f46\" d=\"M1603.2427,-196C1603.2427,-196 1420.5004,-196 1420.5004,-196 1414.5004,-196 1408.5004,-190 1408.5004,-184 1408.5004,-184 1408.5004,-170 1408.5004,-170 1408.5004,-164 1414.5004,-158 1420.5004,-158 1420.5004,-158 1603.2427,-158 1603.2427,-158 1609.2427,-158 1615.2427,-164 1615.2427,-170 1615.2427,-170 1615.2427,-184 1615.2427,-184 1615.2427,-190 1609.2427,-196 1603.2427,-196\"/>\n",
+       "<text text-anchor=\"start\" x=\"1416.436\" y=\"-185\" font-family=\"Helvetica,sans-Serif\" font-size=\"10.00\" fill=\"#000000\">📄 Habib et al., 2017 Nature Methods, zarr</text>\n",
+       "<text text-anchor=\"start\" x=\"1439.7573\" y=\"-175\" font-family=\"Monospace\" font-size=\"10.00\" fill=\"#c0c0c0\">uid=kWwG45Hr26KZUW3g0004</text>\n",
+       "<text text-anchor=\"start\" x=\"1467.8188\" y=\"-165\" font-family=\"Monospace\" font-size=\"10.00\" fill=\"#c0c0c0\">suffix=.anndata.zarr</text>\n",
+       "</g>\n",
+       "<!-- run_xt2ErUgo7KKqUOOAnVad&#45;&gt;artifact_kWwG45Hr26KZUW3g0004 -->\n",
+       "<g id=\"edge9\" class=\"edge\">\n",
+       "<title>run_xt2ErUgo7KKqUOOAnVad&#45;&gt;artifact_kWwG45Hr26KZUW3g0004</title>\n",
+       "<path fill=\"none\" stroke=\"#696969\" d=\"M1018.4021,-246.8074C1109.265,-235.6955 1265.3233,-215.9877 1398.8716,-196 1400.3472,-195.7792 1401.8333,-195.5549 1403.328,-195.3278\"/>\n",
+       "<polygon fill=\"#696969\" stroke=\"#696969\" points=\"1403.7635,-197.0315 1408.4407,-194.5444 1403.2333,-193.5719 1403.7635,-197.0315\"/>\n",
+       "</g>\n",
+       "<!-- collection_obXokdzOnSH2tytJ0000 -->\n",
+       "<g id=\"node11\" class=\"node\">\n",
+       "<title>collection_obXokdzOnSH2tytJ0000</title>\n",
+       "<path fill=\"#f0fff0\" stroke=\"#065f46\" d=\"M1796.8198,-196C1796.8198,-196 1644.9233,-196 1644.9233,-196 1638.9233,-196 1632.9233,-190 1632.9233,-184 1632.9233,-184 1632.9233,-170 1632.9233,-170 1632.9233,-164 1638.9233,-158 1644.9233,-158 1644.9233,-158 1796.8198,-158 1796.8198,-158 1802.8198,-158 1808.8198,-164 1808.8198,-170 1808.8198,-170 1808.8198,-184 1808.8198,-184 1808.8198,-190 1802.8198,-196 1796.8198,-196\"/>\n",
+       "<text text-anchor=\"start\" x=\"1640.8975\" y=\"-185\" font-family=\"Helvetica,sans-Serif\" font-size=\"10.00\" fill=\"#000000\">🍱 View Habib17 (h5ad) in Vitessce</text>\n",
+       "<text text-anchor=\"start\" x=\"1656.5234\" y=\"-175\" font-family=\"Monospace\" font-size=\"10.00\" fill=\"#c0c0c0\">uid=obXokdzOnSH2tytJ0000</text>\n",
+       "<text text-anchor=\"start\" x=\"1689.8804\" y=\"-165\" font-family=\"Monospace\" font-size=\"10.00\" fill=\"#c0c0c0\">version=None</text>\n",
+       "</g>\n",
+       "<!-- run_xt2ErUgo7KKqUOOAnVad&#45;&gt;collection_obXokdzOnSH2tytJ0000 -->\n",
+       "<g id=\"edge10\" class=\"edge\">\n",
+       "<title>run_xt2ErUgo7KKqUOOAnVad&#45;&gt;collection_obXokdzOnSH2tytJ0000</title>\n",
+       "<path fill=\"none\" stroke=\"#696969\" d=\"M1018.1158,-251.929C1144.4889,-244.5916 1405.1201,-226.9583 1623.8716,-196 1625.1725,-195.8159 1626.4823,-195.6258 1627.7994,-195.4303\"/>\n",
+       "<polygon fill=\"#696969\" stroke=\"#696969\" points=\"1628.2331,-197.1344 1632.9118,-194.6501 1627.705,-193.6745 1628.2331,-197.1344\"/>\n",
+       "</g>\n",
+       "<!-- collection_HqfzZmkfYOy20ZNN0000 -->\n",
+       "<g id=\"node12\" class=\"node\">\n",
+       "<title>collection_HqfzZmkfYOy20ZNN0000</title>\n",
+       "<path fill=\"#f0fff0\" stroke=\"#065f46\" d=\"M2091.2155,-196C2091.2155,-196 1838.5276,-196 1838.5276,-196 1832.5276,-196 1826.5276,-190 1826.5276,-184 1826.5276,-184 1826.5276,-170 1826.5276,-170 1826.5276,-164 1832.5276,-158 1838.5276,-158 1838.5276,-158 2091.2155,-158 2091.2155,-158 2097.2155,-158 2103.2155,-164 2103.2155,-170 2103.2155,-170 2103.2155,-184 2103.2155,-184 2103.2155,-190 2097.2155,-196 2091.2155,-196\"/>\n",
+       "<text text-anchor=\"start\" x=\"1834.6997\" y=\"-185\" font-family=\"Helvetica,sans-Serif\" font-size=\"10.00\" fill=\"#000000\">🍱 View PAS OME&#45;TIFF, Neumann et al., 2020 in Vitessce</text>\n",
+       "<text text-anchor=\"start\" x=\"1897.2056\" y=\"-175\" font-family=\"Monospace\" font-size=\"10.00\" fill=\"#c0c0c0\">uid=HqfzZmkfYOy20ZNN0000</text>\n",
+       "<text text-anchor=\"start\" x=\"1933.8804\" y=\"-165\" font-family=\"Monospace\" font-size=\"10.00\" fill=\"#c0c0c0\">version=None</text>\n",
+       "</g>\n",
+       "<!-- run_xt2ErUgo7KKqUOOAnVad&#45;&gt;collection_HqfzZmkfYOy20ZNN0000 -->\n",
+       "<g id=\"edge11\" class=\"edge\">\n",
+       "<title>run_xt2ErUgo7KKqUOOAnVad&#45;&gt;collection_HqfzZmkfYOy20ZNN0000</title>\n",
+       "<path fill=\"none\" stroke=\"#696969\" d=\"M1018.1637,-252.3219C1170.4394,-244.6386 1522.8125,-225.1466 1817.8716,-196 1819.016,-195.887 1820.1652,-195.7721 1821.3187,-195.6554\"/>\n",
+       "<polygon fill=\"#696969\" stroke=\"#696969\" points=\"1821.6077,-197.3851 1826.4026,-195.1332 1821.25,-193.9034 1821.6077,-197.3851\"/>\n",
+       "</g>\n",
+       "</g>\n",
+       "</svg>\n"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "ome_zarr_vc_artifact.view_lineage()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    ":::{note}\n",
+    "\n",
+    "After running `save_vitessce_config`, a Vitessce button will appear next to the dataset in the [Artifacts](https://lamin.ai/vitessce/examples/artifacts) page of the web interface.\n",
     "\n",
     ":::"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 46,
    "metadata": {},
-   "outputs": [],
-   "source": [
-    "vc_artifact.view_lineage()"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\u001b[93m!\u001b[0m cells [(0, 4), (4, 8), (22, 24)] were not run consecutively\n"
+     ]
+    },
+    {
+     "name": "stdin",
+     "output_type": "stream",
+     "text": [
+      "   Do you still want to proceed with finishing? (y/n)  y\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\u001b[92m→\u001b[0m finished Run('xt2ErUgo') after 0d 0h 0m 58s at 2024-12-04 16:01:54 UTC\n",
+      "\u001b[92m→\u001b[0m go to: https://lamin.ai/vitessce/examples/transform/XmcumVqvKZd30002\n",
+      "\u001b[92m→\u001b[0m if you want to update your notebook without re-running it, use `lamin save /Users/markkeller/research/dbmi/vitessce/lamin/lamin-spatial/docs/vitessce.ipynb`\n"
+     ]
+    }
+   ],
    "source": [
     "# [optional] finish run context and auto-save the notebook\n",
-    "# ln.finish()"
+    "ln.finish()"
    ]
   },
   {
@@ -247,6 +1958,10 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
+    "editable": true,
+    "slideshow": {
+     "slide_type": ""
+    },
     "tags": [
      "hide-cell"
     ]
@@ -254,14 +1969,28 @@
    "outputs": [],
    "source": [
     "# clean up artifacts in CI run\n",
-    "zarr_artifact.delete(permanent=True)\n",
-    "vc_artifact.delete(permanent=True)"
+    "h5ad_artifact.delete(permanent=True)\n",
+    "ref_artifact.delete(permanent=True)\n",
+    "\n",
+    "adata_zarr_artifact.delete(permanent=True)\n",
+    "sdata_zarr_artifact.delete(permanent=True)\n",
+    "\n",
+    "ome_tiff_artifact.delete(permanent=True)\n",
+    "offsets_artifact.delete(permanent=True)\n",
+    "\n",
+    "ome_zarr_artifact.delete(permanent=True)\n",
+    "\n",
+    "h5ad_vc_artifact.delete(permanent=True)\n",
+    "adata_zarr_vc_artifact.delete(permanent=True)\n",
+    "sdata_vc_artifact.delete(permanent=True)\n",
+    "ome_tiff_vc_artifact.delete(permanent=True)\n",
+    "ome_zarr_vc_artifact.delete(permanent=True)"
    ]
   }
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "lamindb",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -275,7 +2004,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.11.7"
+   "version": "3.10.0"
   }
  },
  "nbformat": 4,

--- a/docs/vitessce.ipynb
+++ b/docs/vitessce.ipynb
@@ -396,8 +396,9 @@
    },
    "outputs": [],
    "source": [
+    "description_habib17_h5ad = \"View Habib17 (h5ad) in Vitessce\"\n",
     "h5ad_vc_artifact = ln.integrations.save_vitessce_config(\n",
-    "    vc, description=\"View Habib17 (h5ad) in Vitessce\",\n",
+    "    vc, description=description_habib17_h5ad,\n",
     ")"
    ]
   },
@@ -1214,8 +1215,9 @@
    },
    "outputs": [],
    "source": [
+    "description_pas_ome_tiff = \"View PAS OME-TIFF, Neumann et al., 2020 in Vitessce\"\n",
     "ome_tiff_vc_artifact = ln.integrations.save_vitessce_config(\n",
-    "    vc, description=\"View PAS OME-TIFF, Neumann et al., 2020 in Vitessce\",\n",
+    "    vc, description=description_pas_ome_tiff,\n",
     ")"
    ]
   },
@@ -1513,6 +1515,8 @@
    "outputs": [],
    "source": [
     "# clean up artifacts in CI run\n",
+    "ln.Collection.get(name=description_pas_ome_tiff).delete(permanent=True)\n",
+    "ln.Collection.get(name=description_habib17_h5ad).delete(permanent=True)\n",
     "h5ad_artifact.delete(permanent=True)\n",
     "ref_artifact.delete(permanent=True)\n",
     "\n",

--- a/docs/vitessce.ipynb
+++ b/docs/vitessce.ipynb
@@ -47,7 +47,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": null,
    "metadata": {
     "editable": true,
     "slideshow": {
@@ -57,17 +57,7 @@
      "hide-output"
     ]
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "\u001b[92m→\u001b[0m connected lamindb: vitessce/examples\n",
-      "\u001b[92m→\u001b[0m created Transform('BZhZQ6uI'), started new Run('wW6GOHDq') at 2024-12-04 16:10:55 UTC\n",
-      "\u001b[92m→\u001b[0m notebook imports: anndata==0.10.8 generate-tiff-offsets==0.1.9 lamindb==0.77.2 vitessce==3.5.0\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "from urllib.request import urlretrieve\n",
     "from pathlib import Path\n",
@@ -105,7 +95,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": null,
    "metadata": {
     "editable": true,
     "slideshow": {
@@ -138,7 +128,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": null,
    "metadata": {
     "editable": true,
     "slideshow": {
@@ -146,22 +136,7 @@
     },
     "tags": []
    },
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "/Users/markkeller/research/dbmi/vitessce/lamin/hello-world/.venv/lib/python3.10/site-packages/anndata/compat/__init__.py:311: FutureWarning: Moving element from .uns['neighbors']['distances'] to .obsp['distances'].\n",
-      "\n",
-      "This is where adjacency matrices should go now.\n",
-      "  warn(\n",
-      "/Users/markkeller/research/dbmi/vitessce/lamin/hello-world/.venv/lib/python3.10/site-packages/anndata/compat/__init__.py:311: FutureWarning: Moving element from .uns['neighbors']['connectivities'] to .obsp['connectivities'].\n",
-      "\n",
-      "This is where adjacency matrices should go now.\n",
-      "  warn(\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "adata = read_h5ad(h5ad_raw_filepath)"
    ]
@@ -181,7 +156,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": null,
    "metadata": {
     "editable": true,
     "slideshow": {
@@ -196,7 +171,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": null,
    "metadata": {
     "editable": true,
     "slideshow": {
@@ -237,34 +212,15 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": null,
    "metadata": {
     "editable": true,
-    "scrolled": true,
     "slideshow": {
      "slide_type": ""
     },
     "tags": []
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "\u001b[92m→\u001b[0m returning existing artifact with same hash: Artifact(uid='1g3a41z0hggWNBrk0000', is_latest=True, key='vitessce_examples/habib17.h5ad', description='Habib et al., 2017 Nature Methods, h5ad', suffix='.h5ad', type='dataset', size=22586523, hash='-O1gvNOMqXm96TNFJ4yZXQ', _hash_type='md5', _accessor='AnnData', visibility=1, _key_is_virtual=True, storage_id=1, transform_id=17, run_id=79, created_by_id=2, created_at=2024-12-03 21:31:03 UTC)\n"
-     ]
-    },
-    {
-     "data": {
-      "text/plain": [
-       "Artifact(uid='1g3a41z0hggWNBrk0000', is_latest=True, key='vitessce_examples/habib17.h5ad', description='Habib et al., 2017 Nature Methods, h5ad', suffix='.h5ad', type='dataset', size=22586523, hash='-O1gvNOMqXm96TNFJ4yZXQ', _hash_type='md5', _accessor='AnnData', visibility=1, _key_is_virtual=True, storage_id=1, transform_id=18, run_id=85, created_by_id=2, created_at=2024-12-03 21:31:03 UTC)"
-      ]
-     },
-     "execution_count": 6,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "h5ad_artifact = ln.Artifact(\n",
     "    h5ad_processed_filepath,\n",
@@ -290,7 +246,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": null,
    "metadata": {
     "editable": true,
     "slideshow": {
@@ -318,7 +274,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": null,
    "metadata": {
     "editable": true,
     "slideshow": {
@@ -326,15 +282,7 @@
     },
     "tags": []
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "\u001b[92m→\u001b[0m returning existing artifact with same hash: Artifact(uid='O7CTVi6XjnfsceQ20000', is_latest=True, key='vitessce_examples/habib17.reference.json', description='Reference JSON for H5AD file, Habib et al., 2017 Nature Methods', suffix='.json', size=543575, hash='XFOV2X6Bw6_zTugTOEBehg', _hash_type='md5', visibility=1, _key_is_virtual=True, storage_id=1, transform_id=17, run_id=79, created_by_id=2, created_at=2024-12-03 21:31:14 UTC)\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "ref_path = \"./habib17.processed.reference.json\"\n",
     "with open(ref_path, \"w\") as file:\n",
@@ -387,7 +335,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": null,
    "metadata": {
     "editable": true,
     "slideshow": {
@@ -436,7 +384,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": null,
    "metadata": {
     "editable": true,
     "slideshow": {
@@ -446,21 +394,7 @@
      "hide-output"
     ]
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "\u001b[92m→\u001b[0m VitessceConfig references these artifacts:\n",
-      "Artifact(uid='1g3a41z0hggWNBrk0000', is_latest=True, key='vitessce_examples/habib17.h5ad', description='Habib et al., 2017 Nature Methods, h5ad', suffix='.h5ad', type='dataset', size=22586523, hash='-O1gvNOMqXm96TNFJ4yZXQ', _hash_type='md5', _accessor='AnnData', visibility=1, _key_is_virtual=True, storage_id=1, transform_id=18, run_id=85, created_by_id=2, created_at=2024-12-03 21:31:03 UTC)\n",
-      "Artifact(uid='O7CTVi6XjnfsceQ20000', is_latest=True, key='vitessce_examples/habib17.reference.json', description='Reference JSON for H5AD file, Habib et al., 2017 Nature Methods', suffix='.json', size=543575, hash='XFOV2X6Bw6_zTugTOEBehg', _hash_type='md5', visibility=1, _key_is_virtual=True, storage_id=1, transform_id=18, run_id=85, created_by_id=2, created_at=2024-12-03 21:31:14 UTC)\n",
-      "\u001b[93m!\u001b[0m returning existing collection with same hash: Collection(uid='obXokdzOnSH2tytJ0000', is_latest=True, name='View Habib17 (h5ad) in Vitessce', hash='U9WUAN_l9mLUWYqO2pJ9-g', visibility=1, created_by_id=2, transform_id=17, run_id=79, created_at=2024-12-03 21:33:48 UTC)\n",
-      "\u001b[92m→\u001b[0m returning existing artifact with same hash: Artifact(uid='ffUKrGJGNHL3TDhG0000', is_latest=True, description='View Habib17 (h5ad) in Vitessce', suffix='.vitessce.json', size=1365, hash='84eEO5D0fofN-0Sx47tCSA', _hash_type='md5', visibility=1, _key_is_virtual=True, storage_id=1, transform_id=15, run_id=80, created_by_id=2, created_at=2024-12-04 12:59:42 UTC)\n",
-      "\u001b[92m→\u001b[0m VitessceConfig: https://lamin.ai/vitessce/examples/artifact/ffUKrGJGNHL3TDhG0000\n",
-      "\u001b[92m→\u001b[0m Collection: https://lamin.ai/vitessce/examples/collection/obXokdzOnSH2tytJ0000\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "h5ad_vc_artifact = ln.integrations.save_vitessce_config(\n",
     "    vc, description=\"View Habib17 (h5ad) in Vitessce\",\n",
@@ -469,7 +403,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": null,
    "metadata": {
     "editable": true,
     "slideshow": {
@@ -477,115 +411,7 @@
     },
     "tags": []
    },
-   "outputs": [
-    {
-     "data": {
-      "image/svg+xml": [
-       "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"no\"?>\n",
-       "<!DOCTYPE svg PUBLIC \"-//W3C//DTD SVG 1.1//EN\"\n",
-       " \"http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd\">\n",
-       "<!-- Generated by graphviz version 2.40.1 (20161225.0304)\n",
-       " -->\n",
-       "<!-- Title: artifact_ffUKrGJGNHL3TDhG0000 Pages: 1 -->\n",
-       "<svg width=\"756pt\" height=\"288pt\"\n",
-       " viewBox=\"0.00 0.00 755.92 288.00\" xmlns=\"http://www.w3.org/2000/svg\" xmlns:xlink=\"http://www.w3.org/1999/xlink\">\n",
-       "<g id=\"graph0\" class=\"graph\" transform=\"scale(1 1) rotate(0) translate(4 284)\">\n",
-       "<title>artifact_ffUKrGJGNHL3TDhG0000</title>\n",
-       "<polygon fill=\"#ffffff\" stroke=\"transparent\" points=\"-4,4 -4,-284 751.9219,-284 751.9219,4 -4,4\"/>\n",
-       "<!-- artifact_1g3a41z0hggWNBrk0000 -->\n",
-       "<g id=\"node1\" class=\"node\">\n",
-       "<title>artifact_1g3a41z0hggWNBrk0000</title>\n",
-       "<path fill=\"#f0fff0\" stroke=\"#065f46\" d=\"M199.8433,-196C199.8433,-196 12.0522,-196 12.0522,-196 6.0522,-196 .0522,-190 .0522,-184 .0522,-184 .0522,-170 .0522,-170 .0522,-164 6.0522,-158 12.0522,-158 12.0522,-158 199.8433,-158 199.8433,-158 205.8433,-158 211.8433,-164 211.8433,-170 211.8433,-170 211.8433,-184 211.8433,-184 211.8433,-190 205.8433,-196 199.8433,-196\"/>\n",
-       "<text text-anchor=\"start\" x=\"8\" y=\"-185\" font-family=\"Helvetica,sans-Serif\" font-size=\"10.00\" fill=\"#000000\">📄 Habib et al., 2017 Nature Methods, h5ad</text>\n",
-       "<text text-anchor=\"start\" x=\"39.0947\" y=\"-175\" font-family=\"Monospace\" font-size=\"10.00\" fill=\"#c0c0c0\">uid=1g3a41z0hggWNBrk0000</text>\n",
-       "<text text-anchor=\"start\" x=\"78.8457\" y=\"-165\" font-family=\"Monospace\" font-size=\"10.00\" fill=\"#c0c0c0\">suffix=.h5ad</text>\n",
-       "</g>\n",
-       "<!-- run_14xlrpxdBiGrZAfL5oOg -->\n",
-       "<g id=\"node2\" class=\"node\">\n",
-       "<title>run_14xlrpxdBiGrZAfL5oOg</title>\n",
-       "<path fill=\"#dcdcdc\" stroke=\"#065f46\" d=\"M312.6902,-122C312.6902,-122 185.2053,-122 185.2053,-122 179.2053,-122 173.2053,-116 173.2053,-110 173.2053,-110 173.2053,-86 173.2053,-86 173.2053,-80 179.2053,-74 185.2053,-74 185.2053,-74 312.6902,-74 312.6902,-74 318.6902,-74 324.6902,-80 324.6902,-86 324.6902,-86 324.6902,-110 324.6902,-110 324.6902,-116 318.6902,-122 312.6902,-122\"/>\n",
-       "<text text-anchor=\"start\" x=\"193.5317\" y=\"-111\" font-family=\"Helvetica,sans-Serif\" font-size=\"10.00\" fill=\"#000000\">🔧 save_vitessce_config</text>\n",
-       "<text text-anchor=\"start\" x=\"194.9731\" y=\"-101\" font-family=\"Monospace\" font-size=\"10.00\" fill=\"#c0c0c0\">uid=kup03MJBsIVa0002</text>\n",
-       "<text text-anchor=\"start\" x=\"184.7461\" y=\"-91\" font-family=\"Monospace\" font-size=\"10.00\" fill=\"#c0c0c0\">type=function, user=mkeller7</text>\n",
-       "<text text-anchor=\"start\" x=\"181.0767\" y=\"-81\" font-family=\"Monospace\" font-size=\"10.00\" fill=\"#c0c0c0\">run=2024&#45;12&#45;04 16:11:08 UTC</text>\n",
-       "</g>\n",
-       "<!-- artifact_1g3a41z0hggWNBrk0000&#45;&gt;run_14xlrpxdBiGrZAfL5oOg -->\n",
-       "<g id=\"edge1\" class=\"edge\">\n",
-       "<title>artifact_1g3a41z0hggWNBrk0000&#45;&gt;run_14xlrpxdBiGrZAfL5oOg</title>\n",
-       "<path fill=\"none\" stroke=\"#696969\" d=\"M140.5641,-157.8763C158.6999,-147.8572 181.1955,-135.4296 200.9839,-124.4975\"/>\n",
-       "<polygon fill=\"#696969\" stroke=\"#696969\" points=\"201.8938,-125.9942 205.4241,-122.0445 200.2013,-122.9306 201.8938,-125.9942\"/>\n",
-       "</g>\n",
-       "<!-- artifact_ffUKrGJGNHL3TDhG0000 -->\n",
-       "<g id=\"node4\" class=\"node\">\n",
-       "<title>artifact_ffUKrGJGNHL3TDhG0000</title>\n",
-       "<path fill=\"#10b981\" stroke=\"#065f46\" d=\"M324.896,-38C324.896,-38 172.9995,-38 172.9995,-38 166.9995,-38 160.9995,-32 160.9995,-26 160.9995,-26 160.9995,-12 160.9995,-12 160.9995,-6 166.9995,0 172.9995,0 172.9995,0 324.896,0 324.896,0 330.896,0 336.896,-6 336.896,-12 336.896,-12 336.896,-26 336.896,-26 336.896,-32 330.896,-38 324.896,-38\"/>\n",
-       "<text text-anchor=\"start\" x=\"168.9736\" y=\"-27\" font-family=\"Helvetica,sans-Serif\" font-size=\"10.00\" fill=\"#000000\">📄 View Habib17 (h5ad) in Vitessce</text>\n",
-       "<text text-anchor=\"start\" x=\"180.5347\" y=\"-17\" font-family=\"Monospace\" font-size=\"10.00\" fill=\"#c0c0c0\">uid=ffUKrGJGNHL3TDhG0000</text>\n",
-       "<text text-anchor=\"start\" x=\"204.3457\" y=\"-7\" font-family=\"Monospace\" font-size=\"10.00\" fill=\"#c0c0c0\">suffix=.vitessce.json</text>\n",
-       "</g>\n",
-       "<!-- run_14xlrpxdBiGrZAfL5oOg&#45;&gt;artifact_ffUKrGJGNHL3TDhG0000 -->\n",
-       "<g id=\"edge3\" class=\"edge\">\n",
-       "<title>run_14xlrpxdBiGrZAfL5oOg&#45;&gt;artifact_ffUKrGJGNHL3TDhG0000</title>\n",
-       "<path fill=\"none\" stroke=\"#696969\" d=\"M248.9478,-73.8681C248.9478,-64.2201 248.9478,-53.1228 248.9478,-43.4439\"/>\n",
-       "<polygon fill=\"#696969\" stroke=\"#696969\" points=\"250.6978,-43.2308 248.9478,-38.2309 247.1978,-43.2309 250.6978,-43.2308\"/>\n",
-       "</g>\n",
-       "<!-- artifact_O7CTVi6XjnfsceQ20000 -->\n",
-       "<g id=\"node3\" class=\"node\">\n",
-       "<title>artifact_O7CTVi6XjnfsceQ20000</title>\n",
-       "<path fill=\"#f0fff0\" stroke=\"#065f46\" d=\"M542.1461,-196C542.1461,-196 241.7494,-196 241.7494,-196 235.7494,-196 229.7494,-190 229.7494,-184 229.7494,-184 229.7494,-170 229.7494,-170 229.7494,-164 235.7494,-158 241.7494,-158 241.7494,-158 542.1461,-158 542.1461,-158 548.1461,-158 554.1461,-164 554.1461,-170 554.1461,-170 554.1461,-184 554.1461,-184 554.1461,-190 548.1461,-196 542.1461,-196\"/>\n",
-       "<text text-anchor=\"start\" x=\"237.5986\" y=\"-185\" font-family=\"Helvetica,sans-Serif\" font-size=\"10.00\" fill=\"#000000\">📄 Reference JSON for H5AD file, Habib et al., 2017 Nature Methods</text>\n",
-       "<text text-anchor=\"start\" x=\"327.6924\" y=\"-175\" font-family=\"Monospace\" font-size=\"10.00\" fill=\"#c0c0c0\">uid=O7CTVi6XjnfsceQ20000</text>\n",
-       "<text text-anchor=\"start\" x=\"366.7964\" y=\"-165\" font-family=\"Monospace\" font-size=\"10.00\" fill=\"#c0c0c0\">suffix=.json</text>\n",
-       "</g>\n",
-       "<!-- artifact_O7CTVi6XjnfsceQ20000&#45;&gt;run_14xlrpxdBiGrZAfL5oOg -->\n",
-       "<g id=\"edge2\" class=\"edge\">\n",
-       "<title>artifact_O7CTVi6XjnfsceQ20000&#45;&gt;run_14xlrpxdBiGrZAfL5oOg</title>\n",
-       "<path fill=\"none\" stroke=\"#696969\" d=\"M357.3314,-157.8763C339.1956,-147.8572 316.7,-135.4296 296.9117,-124.4975\"/>\n",
-       "<polygon fill=\"#696969\" stroke=\"#696969\" points=\"297.6942,-122.9306 292.4714,-122.0445 296.0017,-125.9942 297.6942,-122.9306\"/>\n",
-       "</g>\n",
-       "<!-- run_wW6GOHDq44lbrdKi08cr -->\n",
-       "<g id=\"node5\" class=\"node\">\n",
-       "<title>run_wW6GOHDq44lbrdKi08cr</title>\n",
-       "<path fill=\"#dcdcdc\" stroke=\"#065f46\" d=\"M456.428,-280C456.428,-280 327.4675,-280 327.4675,-280 321.4675,-280 315.4675,-274 315.4675,-268 315.4675,-268 315.4675,-244 315.4675,-244 315.4675,-238 321.4675,-232 327.4675,-232 327.4675,-232 456.428,-232 456.428,-232 462.428,-232 468.428,-238 468.428,-244 468.428,-244 468.428,-268 468.428,-268 468.428,-274 462.428,-280 456.428,-280\"/>\n",
-       "<text text-anchor=\"start\" x=\"365.25\" y=\"-269\" font-family=\"Helvetica,sans-Serif\" font-size=\"10.00\" fill=\"#000000\">📔 Vitessce</text>\n",
-       "<text text-anchor=\"start\" x=\"335.6685\" y=\"-259\" font-family=\"Monospace\" font-size=\"10.00\" fill=\"#c0c0c0\">uid=BZhZQ6uIbkWv0000</text>\n",
-       "<text text-anchor=\"start\" x=\"324.6846\" y=\"-249\" font-family=\"Monospace\" font-size=\"10.00\" fill=\"#c0c0c0\">type=notebook, user=mkeller7</text>\n",
-       "<text text-anchor=\"start\" x=\"323.708\" y=\"-239\" font-family=\"Monospace\" font-size=\"10.00\" fill=\"#c0c0c0\">run=2024&#45;12&#45;04 16:10:55 UTC</text>\n",
-       "</g>\n",
-       "<!-- run_wW6GOHDq44lbrdKi08cr&#45;&gt;artifact_1g3a41z0hggWNBrk0000 -->\n",
-       "<g id=\"edge4\" class=\"edge\">\n",
-       "<title>run_wW6GOHDq44lbrdKi08cr&#45;&gt;artifact_1g3a41z0hggWNBrk0000</title>\n",
-       "<path fill=\"none\" stroke=\"#696969\" d=\"M315.6807,-234.9332C273.7017,-223.3376 221.8323,-209.0101 180.1795,-197.5046\"/>\n",
-       "<polygon fill=\"#696969\" stroke=\"#696969\" points=\"180.4374,-195.7603 175.1519,-196.1158 179.5054,-199.134 180.4374,-195.7603\"/>\n",
-       "</g>\n",
-       "<!-- run_wW6GOHDq44lbrdKi08cr&#45;&gt;artifact_O7CTVi6XjnfsceQ20000 -->\n",
-       "<g id=\"edge5\" class=\"edge\">\n",
-       "<title>run_wW6GOHDq44lbrdKi08cr&#45;&gt;artifact_O7CTVi6XjnfsceQ20000</title>\n",
-       "<path fill=\"none\" stroke=\"#696969\" d=\"M391.9478,-231.8681C391.9478,-222.2201 391.9478,-211.1228 391.9478,-201.4439\"/>\n",
-       "<polygon fill=\"#696969\" stroke=\"#696969\" points=\"393.6978,-201.2308 391.9478,-196.2309 390.1978,-201.2309 393.6978,-201.2308\"/>\n",
-       "</g>\n",
-       "<!-- collection_obXokdzOnSH2tytJ0000 -->\n",
-       "<g id=\"node6\" class=\"node\">\n",
-       "<title>collection_obXokdzOnSH2tytJ0000</title>\n",
-       "<path fill=\"#f0fff0\" stroke=\"#065f46\" d=\"M735.896,-196C735.896,-196 583.9995,-196 583.9995,-196 577.9995,-196 571.9995,-190 571.9995,-184 571.9995,-184 571.9995,-170 571.9995,-170 571.9995,-164 577.9995,-158 583.9995,-158 583.9995,-158 735.896,-158 735.896,-158 741.896,-158 747.896,-164 747.896,-170 747.896,-170 747.896,-184 747.896,-184 747.896,-190 741.896,-196 735.896,-196\"/>\n",
-       "<text text-anchor=\"start\" x=\"579.9736\" y=\"-185\" font-family=\"Helvetica,sans-Serif\" font-size=\"10.00\" fill=\"#000000\">🍱 View Habib17 (h5ad) in Vitessce</text>\n",
-       "<text text-anchor=\"start\" x=\"595.5996\" y=\"-175\" font-family=\"Monospace\" font-size=\"10.00\" fill=\"#c0c0c0\">uid=obXokdzOnSH2tytJ0000</text>\n",
-       "<text text-anchor=\"start\" x=\"628.9565\" y=\"-165\" font-family=\"Monospace\" font-size=\"10.00\" fill=\"#c0c0c0\">version=None</text>\n",
-       "</g>\n",
-       "<!-- run_wW6GOHDq44lbrdKi08cr&#45;&gt;collection_obXokdzOnSH2tytJ0000 -->\n",
-       "<g id=\"edge6\" class=\"edge\">\n",
-       "<title>run_wW6GOHDq44lbrdKi08cr&#45;&gt;collection_obXokdzOnSH2tytJ0000</title>\n",
-       "<path fill=\"none\" stroke=\"#696969\" d=\"M468.3871,-233.4675C506.7362,-222.1631 552.851,-208.5696 590.2243,-197.5528\"/>\n",
-       "<polygon fill=\"#696969\" stroke=\"#696969\" points=\"590.9028,-199.1773 595.2039,-196.0849 589.9131,-195.8201 590.9028,-199.1773\"/>\n",
-       "</g>\n",
-       "</g>\n",
-       "</svg>\n"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    }
-   ],
+   "outputs": [],
    "source": [
     "h5ad_vc_artifact.view_lineage()"
    ]
@@ -664,7 +490,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": null,
    "metadata": {
     "editable": true,
     "slideshow": {
@@ -679,7 +505,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": null,
    "metadata": {
     "editable": true,
     "slideshow": {
@@ -687,22 +513,7 @@
     },
     "tags": []
    },
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "/Users/markkeller/research/dbmi/vitessce/lamin/hello-world/.venv/lib/python3.10/site-packages/anndata/compat/__init__.py:311: FutureWarning: Moving element from .uns['neighbors']['distances'] to .obsp['distances'].\n",
-      "\n",
-      "This is where adjacency matrices should go now.\n",
-      "  warn(\n",
-      "/Users/markkeller/research/dbmi/vitessce/lamin/hello-world/.venv/lib/python3.10/site-packages/anndata/compat/__init__.py:311: FutureWarning: Moving element from .uns['neighbors']['connectivities'] to .obsp['connectivities'].\n",
-      "\n",
-      "This is where adjacency matrices should go now.\n",
-      "  warn(\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "adata = read_h5ad(h5ad_raw_filepath)"
    ]
@@ -722,7 +533,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": null,
    "metadata": {
     "editable": true,
     "slideshow": {
@@ -750,7 +561,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": null,
    "metadata": {
     "editable": true,
     "slideshow": {
@@ -778,34 +589,15 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": null,
    "metadata": {
     "editable": true,
-    "scrolled": true,
     "slideshow": {
      "slide_type": ""
     },
     "tags": []
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "\u001b[92m→\u001b[0m returning existing artifact with same hash: Artifact(uid='kWwG45Hr26KZUW3g0004', is_latest=True, key='vitessce_examples/habib17.adata.zarr', description='Habib et al., 2017 Nature Methods, zarr', suffix='.anndata.zarr', type='dataset', size=10601062, hash='Ap_EL5yPdfyD07Xjpe1SlA', n_objects=208, _hash_type='md5-d', _accessor='AnnData', visibility=1, _key_is_virtual=True, storage_id=1, transform_id=17, run_id=79, created_by_id=2, created_at=2024-12-04 16:01:11 UTC)\n"
-     ]
-    },
-    {
-     "data": {
-      "text/plain": [
-       "Artifact(uid='kWwG45Hr26KZUW3g0004', is_latest=True, key='vitessce_examples/habib17.adata.zarr', description='Habib et al., 2017 Nature Methods, zarr', suffix='.anndata.zarr', type='dataset', size=10601062, hash='Ap_EL5yPdfyD07Xjpe1SlA', n_objects=208, _hash_type='md5-d', _accessor='AnnData', visibility=1, _key_is_virtual=True, storage_id=1, transform_id=18, run_id=85, created_by_id=2, created_at=2024-12-04 16:01:11 UTC)"
-      ]
-     },
-     "execution_count": 16,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "adata_zarr_artifact = ln.Artifact(\n",
     "    zarr_processed_filepath,\n",
@@ -845,7 +637,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
+   "execution_count": null,
    "metadata": {
     "editable": true,
     "slideshow": {
@@ -895,7 +687,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 18,
+   "execution_count": null,
    "metadata": {
     "editable": true,
     "slideshow": {
@@ -905,19 +697,7 @@
      "hide-output"
     ]
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "\u001b[92m→\u001b[0m VitessceConfig references these artifacts:\n",
-      "Artifact(uid='kWwG45Hr26KZUW3g0004', is_latest=True, key='vitessce_examples/habib17.adata.zarr', description='Habib et al., 2017 Nature Methods, zarr', suffix='.anndata.zarr', type='dataset', size=10601062, hash='Ap_EL5yPdfyD07Xjpe1SlA', n_objects=208, _hash_type='md5-d', _accessor='AnnData', visibility=1, _key_is_virtual=True, storage_id=1, transform_id=18, run_id=85, created_by_id=2, created_at=2024-12-04 16:01:11 UTC)\n",
-      "\u001b[92m→\u001b[0m returning existing artifact with same hash: Artifact(uid='J4tMB6qAeHvsgEsp0000', is_latest=True, description='View Habib17 in Vitessce', suffix='.vitessce.json', size=1247, hash='MN-N-I_cn9K8Y2Pe59u1Fw', _hash_type='md5', visibility=1, _key_is_virtual=True, storage_id=1, transform_id=15, run_id=81, created_by_id=2, created_at=2024-12-04 14:32:11 UTC)\n",
-      "\u001b[92m→\u001b[0m VitessceConfig: https://lamin.ai/vitessce/examples/artifact/J4tMB6qAeHvsgEsp0000\n",
-      "\u001b[92m→\u001b[0m Dataset: https://lamin.ai/vitessce/examples/artifact/kWwG45Hr26KZUW3g0004\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "adata_zarr_vc_artifact = ln.integrations.save_vitessce_config(\n",
     "    vc, description=\"View Habib17 in Vitessce\",\n",
@@ -926,7 +706,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 19,
+   "execution_count": null,
    "metadata": {
     "editable": true,
     "slideshow": {
@@ -934,123 +714,7 @@
     },
     "tags": []
    },
-   "outputs": [
-    {
-     "data": {
-      "image/svg+xml": [
-       "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"no\"?>\n",
-       "<!DOCTYPE svg PUBLIC \"-//W3C//DTD SVG 1.1//EN\"\n",
-       " \"http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd\">\n",
-       "<!-- Generated by graphviz version 2.40.1 (20161225.0304)\n",
-       " -->\n",
-       "<!-- Title: artifact_J4tMB6qAeHvsgEsp0000 Pages: 1 -->\n",
-       "<svg width=\"980pt\" height=\"288pt\"\n",
-       " viewBox=\"0.00 0.00 980.41 288.00\" xmlns=\"http://www.w3.org/2000/svg\" xmlns:xlink=\"http://www.w3.org/1999/xlink\">\n",
-       "<g id=\"graph0\" class=\"graph\" transform=\"scale(1 1) rotate(0) translate(4 284)\">\n",
-       "<title>artifact_J4tMB6qAeHvsgEsp0000</title>\n",
-       "<polygon fill=\"#ffffff\" stroke=\"transparent\" points=\"-4,4 -4,-284 976.4097,-284 976.4097,4 -4,4\"/>\n",
-       "<!-- artifact_kWwG45Hr26KZUW3g0004 -->\n",
-       "<g id=\"node1\" class=\"node\">\n",
-       "<title>artifact_kWwG45Hr26KZUW3g0004</title>\n",
-       "<path fill=\"#f0fff0\" stroke=\"#065f46\" d=\"M194.8067,-196C194.8067,-196 12.0644,-196 12.0644,-196 6.0644,-196 .0644,-190 .0644,-184 .0644,-184 .0644,-170 .0644,-170 .0644,-164 6.0644,-158 12.0644,-158 12.0644,-158 194.8067,-158 194.8067,-158 200.8067,-158 206.8067,-164 206.8067,-170 206.8067,-170 206.8067,-184 206.8067,-184 206.8067,-190 200.8067,-196 194.8067,-196\"/>\n",
-       "<text text-anchor=\"start\" x=\"8\" y=\"-185\" font-family=\"Helvetica,sans-Serif\" font-size=\"10.00\" fill=\"#000000\">📄 Habib et al., 2017 Nature Methods, zarr</text>\n",
-       "<text text-anchor=\"start\" x=\"31.3213\" y=\"-175\" font-family=\"Monospace\" font-size=\"10.00\" fill=\"#c0c0c0\">uid=kWwG45Hr26KZUW3g0004</text>\n",
-       "<text text-anchor=\"start\" x=\"59.3828\" y=\"-165\" font-family=\"Monospace\" font-size=\"10.00\" fill=\"#c0c0c0\">suffix=.anndata.zarr</text>\n",
-       "</g>\n",
-       "<!-- run_xdpOXGoyQMEMPv19bfbw -->\n",
-       "<g id=\"node2\" class=\"node\">\n",
-       "<title>run_xdpOXGoyQMEMPv19bfbw</title>\n",
-       "<path fill=\"#dcdcdc\" stroke=\"#065f46\" d=\"M167.178,-122C167.178,-122 39.6931,-122 39.6931,-122 33.6931,-122 27.6931,-116 27.6931,-110 27.6931,-110 27.6931,-86 27.6931,-86 27.6931,-80 33.6931,-74 39.6931,-74 39.6931,-74 167.178,-74 167.178,-74 173.178,-74 179.178,-80 179.178,-86 179.178,-86 179.178,-110 179.178,-110 179.178,-116 173.178,-122 167.178,-122\"/>\n",
-       "<text text-anchor=\"start\" x=\"48.0195\" y=\"-111\" font-family=\"Helvetica,sans-Serif\" font-size=\"10.00\" fill=\"#000000\">🔧 save_vitessce_config</text>\n",
-       "<text text-anchor=\"start\" x=\"49.4609\" y=\"-101\" font-family=\"Monospace\" font-size=\"10.00\" fill=\"#c0c0c0\">uid=kup03MJBsIVa0002</text>\n",
-       "<text text-anchor=\"start\" x=\"39.2339\" y=\"-91\" font-family=\"Monospace\" font-size=\"10.00\" fill=\"#c0c0c0\">type=function, user=mkeller7</text>\n",
-       "<text text-anchor=\"start\" x=\"35.5645\" y=\"-81\" font-family=\"Monospace\" font-size=\"10.00\" fill=\"#c0c0c0\">run=2024&#45;12&#45;04 16:11:24 UTC</text>\n",
-       "</g>\n",
-       "<!-- artifact_kWwG45Hr26KZUW3g0004&#45;&gt;run_xdpOXGoyQMEMPv19bfbw -->\n",
-       "<g id=\"edge1\" class=\"edge\">\n",
-       "<title>artifact_kWwG45Hr26KZUW3g0004&#45;&gt;run_xdpOXGoyQMEMPv19bfbw</title>\n",
-       "<path fill=\"none\" stroke=\"#696969\" d=\"M103.4355,-157.8763C103.4355,-148.6991 103.4355,-137.5013 103.4355,-127.2829\"/>\n",
-       "<polygon fill=\"#696969\" stroke=\"#696969\" points=\"105.1856,-127.0445 103.4355,-122.0445 101.6856,-127.0445 105.1856,-127.0445\"/>\n",
-       "</g>\n",
-       "<!-- artifact_J4tMB6qAeHvsgEsp0000 -->\n",
-       "<g id=\"node3\" class=\"node\">\n",
-       "<title>artifact_J4tMB6qAeHvsgEsp0000</title>\n",
-       "<path fill=\"#10b981\" stroke=\"#065f46\" d=\"M166.0753,-38C166.0753,-38 40.7958,-38 40.7958,-38 34.7958,-38 28.7958,-32 28.7958,-26 28.7958,-26 28.7958,-12 28.7958,-12 28.7958,-6 34.7958,0 40.7958,0 40.7958,0 166.0753,0 166.0753,0 172.0753,0 178.0753,-6 178.0753,-12 178.0753,-12 178.0753,-26 178.0753,-26 178.0753,-32 172.0753,-38 166.0753,-38\"/>\n",
-       "<text text-anchor=\"start\" x=\"39.3037\" y=\"-27\" font-family=\"Helvetica,sans-Serif\" font-size=\"10.00\" fill=\"#000000\">📄 View Habib17 in Vitessce</text>\n",
-       "<text text-anchor=\"start\" x=\"36.8657\" y=\"-17\" font-family=\"Monospace\" font-size=\"10.00\" fill=\"#c0c0c0\">uid=J4tMB6qAeHvsgEsp0000</text>\n",
-       "<text text-anchor=\"start\" x=\"58.8335\" y=\"-7\" font-family=\"Monospace\" font-size=\"10.00\" fill=\"#c0c0c0\">suffix=.vitessce.json</text>\n",
-       "</g>\n",
-       "<!-- run_xdpOXGoyQMEMPv19bfbw&#45;&gt;artifact_J4tMB6qAeHvsgEsp0000 -->\n",
-       "<g id=\"edge2\" class=\"edge\">\n",
-       "<title>run_xdpOXGoyQMEMPv19bfbw&#45;&gt;artifact_J4tMB6qAeHvsgEsp0000</title>\n",
-       "<path fill=\"none\" stroke=\"#696969\" d=\"M103.4355,-73.8681C103.4355,-64.2201 103.4355,-53.1228 103.4355,-43.4439\"/>\n",
-       "<polygon fill=\"#696969\" stroke=\"#696969\" points=\"105.1856,-43.2308 103.4355,-38.2309 101.6856,-43.2309 105.1856,-43.2308\"/>\n",
-       "</g>\n",
-       "<!-- run_wW6GOHDq44lbrdKi08cr -->\n",
-       "<g id=\"node4\" class=\"node\">\n",
-       "<title>run_wW6GOHDq44lbrdKi08cr</title>\n",
-       "<path fill=\"#dcdcdc\" stroke=\"#065f46\" d=\"M537.9158,-280C537.9158,-280 408.9553,-280 408.9553,-280 402.9553,-280 396.9553,-274 396.9553,-268 396.9553,-268 396.9553,-244 396.9553,-244 396.9553,-238 402.9553,-232 408.9553,-232 408.9553,-232 537.9158,-232 537.9158,-232 543.9158,-232 549.9158,-238 549.9158,-244 549.9158,-244 549.9158,-268 549.9158,-268 549.9158,-274 543.9158,-280 537.9158,-280\"/>\n",
-       "<text text-anchor=\"start\" x=\"446.7378\" y=\"-269\" font-family=\"Helvetica,sans-Serif\" font-size=\"10.00\" fill=\"#000000\">📔 Vitessce</text>\n",
-       "<text text-anchor=\"start\" x=\"417.1563\" y=\"-259\" font-family=\"Monospace\" font-size=\"10.00\" fill=\"#c0c0c0\">uid=BZhZQ6uIbkWv0000</text>\n",
-       "<text text-anchor=\"start\" x=\"406.1724\" y=\"-249\" font-family=\"Monospace\" font-size=\"10.00\" fill=\"#c0c0c0\">type=notebook, user=mkeller7</text>\n",
-       "<text text-anchor=\"start\" x=\"405.1958\" y=\"-239\" font-family=\"Monospace\" font-size=\"10.00\" fill=\"#c0c0c0\">run=2024&#45;12&#45;04 16:10:55 UTC</text>\n",
-       "</g>\n",
-       "<!-- run_wW6GOHDq44lbrdKi08cr&#45;&gt;artifact_kWwG45Hr26KZUW3g0004 -->\n",
-       "<g id=\"edge5\" class=\"edge\">\n",
-       "<title>run_wW6GOHDq44lbrdKi08cr&#45;&gt;artifact_kWwG45Hr26KZUW3g0004</title>\n",
-       "<path fill=\"none\" stroke=\"#696969\" d=\"M396.7713,-239.6311C339.0212,-227.3007 259.5247,-210.3271 197.856,-197.16\"/>\n",
-       "<polygon fill=\"#696969\" stroke=\"#696969\" points=\"197.9534,-195.3915 192.6982,-196.0588 197.2225,-198.8143 197.9534,-195.3915\"/>\n",
-       "</g>\n",
-       "<!-- artifact_1g3a41z0hggWNBrk0000 -->\n",
-       "<g id=\"node5\" class=\"node\">\n",
-       "<title>artifact_1g3a41z0hggWNBrk0000</title>\n",
-       "<path fill=\"#f0fff0\" stroke=\"#065f46\" d=\"M424.3311,-196C424.3311,-196 236.54,-196 236.54,-196 230.54,-196 224.54,-190 224.54,-184 224.54,-184 224.54,-170 224.54,-170 224.54,-164 230.54,-158 236.54,-158 236.54,-158 424.3311,-158 424.3311,-158 430.3311,-158 436.3311,-164 436.3311,-170 436.3311,-170 436.3311,-184 436.3311,-184 436.3311,-190 430.3311,-196 424.3311,-196\"/>\n",
-       "<text text-anchor=\"start\" x=\"232.4878\" y=\"-185\" font-family=\"Helvetica,sans-Serif\" font-size=\"10.00\" fill=\"#000000\">📄 Habib et al., 2017 Nature Methods, h5ad</text>\n",
-       "<text text-anchor=\"start\" x=\"263.5825\" y=\"-175\" font-family=\"Monospace\" font-size=\"10.00\" fill=\"#c0c0c0\">uid=1g3a41z0hggWNBrk0000</text>\n",
-       "<text text-anchor=\"start\" x=\"303.3335\" y=\"-165\" font-family=\"Monospace\" font-size=\"10.00\" fill=\"#c0c0c0\">suffix=.h5ad</text>\n",
-       "</g>\n",
-       "<!-- run_wW6GOHDq44lbrdKi08cr&#45;&gt;artifact_1g3a41z0hggWNBrk0000 -->\n",
-       "<g id=\"edge3\" class=\"edge\">\n",
-       "<title>run_wW6GOHDq44lbrdKi08cr&#45;&gt;artifact_1g3a41z0hggWNBrk0000</title>\n",
-       "<path fill=\"none\" stroke=\"#696969\" d=\"M429.7538,-231.8681C410.6726,-221.3267 388.4598,-209.0553 369.8856,-198.7941\"/>\n",
-       "<polygon fill=\"#696969\" stroke=\"#696969\" points=\"370.4687,-197.1169 365.2458,-196.2309 368.7762,-200.1805 370.4687,-197.1169\"/>\n",
-       "</g>\n",
-       "<!-- artifact_O7CTVi6XjnfsceQ20000 -->\n",
-       "<g id=\"node6\" class=\"node\">\n",
-       "<title>artifact_O7CTVi6XjnfsceQ20000</title>\n",
-       "<path fill=\"#f0fff0\" stroke=\"#065f46\" d=\"M766.6339,-196C766.6339,-196 466.2372,-196 466.2372,-196 460.2372,-196 454.2372,-190 454.2372,-184 454.2372,-184 454.2372,-170 454.2372,-170 454.2372,-164 460.2372,-158 466.2372,-158 466.2372,-158 766.6339,-158 766.6339,-158 772.6339,-158 778.6339,-164 778.6339,-170 778.6339,-170 778.6339,-184 778.6339,-184 778.6339,-190 772.6339,-196 766.6339,-196\"/>\n",
-       "<text text-anchor=\"start\" x=\"462.0864\" y=\"-185\" font-family=\"Helvetica,sans-Serif\" font-size=\"10.00\" fill=\"#000000\">📄 Reference JSON for H5AD file, Habib et al., 2017 Nature Methods</text>\n",
-       "<text text-anchor=\"start\" x=\"552.1802\" y=\"-175\" font-family=\"Monospace\" font-size=\"10.00\" fill=\"#c0c0c0\">uid=O7CTVi6XjnfsceQ20000</text>\n",
-       "<text text-anchor=\"start\" x=\"591.2842\" y=\"-165\" font-family=\"Monospace\" font-size=\"10.00\" fill=\"#c0c0c0\">suffix=.json</text>\n",
-       "</g>\n",
-       "<!-- run_wW6GOHDq44lbrdKi08cr&#45;&gt;artifact_O7CTVi6XjnfsceQ20000 -->\n",
-       "<g id=\"edge4\" class=\"edge\">\n",
-       "<title>run_wW6GOHDq44lbrdKi08cr&#45;&gt;artifact_O7CTVi6XjnfsceQ20000</title>\n",
-       "<path fill=\"none\" stroke=\"#696969\" d=\"M517.1173,-231.8681C536.1985,-221.3267 558.4113,-209.0553 576.9855,-198.7941\"/>\n",
-       "<polygon fill=\"#696969\" stroke=\"#696969\" points=\"578.0949,-200.1805 581.6252,-196.2309 576.4024,-197.1169 578.0949,-200.1805\"/>\n",
-       "</g>\n",
-       "<!-- collection_obXokdzOnSH2tytJ0000 -->\n",
-       "<g id=\"node7\" class=\"node\">\n",
-       "<title>collection_obXokdzOnSH2tytJ0000</title>\n",
-       "<path fill=\"#f0fff0\" stroke=\"#065f46\" d=\"M960.3838,-196C960.3838,-196 808.4873,-196 808.4873,-196 802.4873,-196 796.4873,-190 796.4873,-184 796.4873,-184 796.4873,-170 796.4873,-170 796.4873,-164 802.4873,-158 808.4873,-158 808.4873,-158 960.3838,-158 960.3838,-158 966.3838,-158 972.3838,-164 972.3838,-170 972.3838,-170 972.3838,-184 972.3838,-184 972.3838,-190 966.3838,-196 960.3838,-196\"/>\n",
-       "<text text-anchor=\"start\" x=\"804.4614\" y=\"-185\" font-family=\"Helvetica,sans-Serif\" font-size=\"10.00\" fill=\"#000000\">🍱 View Habib17 (h5ad) in Vitessce</text>\n",
-       "<text text-anchor=\"start\" x=\"820.0874\" y=\"-175\" font-family=\"Monospace\" font-size=\"10.00\" fill=\"#c0c0c0\">uid=obXokdzOnSH2tytJ0000</text>\n",
-       "<text text-anchor=\"start\" x=\"853.4443\" y=\"-165\" font-family=\"Monospace\" font-size=\"10.00\" fill=\"#c0c0c0\">version=None</text>\n",
-       "</g>\n",
-       "<!-- run_wW6GOHDq44lbrdKi08cr&#45;&gt;collection_obXokdzOnSH2tytJ0000 -->\n",
-       "<g id=\"edge6\" class=\"edge\">\n",
-       "<title>run_wW6GOHDq44lbrdKi08cr&#45;&gt;collection_obXokdzOnSH2tytJ0000</title>\n",
-       "<path fill=\"none\" stroke=\"#696969\" d=\"M549.9149,-241.4884C613.5076,-229.3973 706.3822,-211.6821 787.4355,-196 788.7255,-195.7504 790.025,-195.4988 791.3324,-195.2454\"/>\n",
-       "<polygon fill=\"#696969\" stroke=\"#696969\" points=\"791.8353,-196.9306 796.4106,-194.2604 791.1688,-193.4946 791.8353,-196.9306\"/>\n",
-       "</g>\n",
-       "</g>\n",
-       "</svg>\n"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    }
-   ],
+   "outputs": [],
    "source": [
     "adata_zarr_vc_artifact.view_lineage()"
    ]
@@ -1100,7 +764,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 20,
+   "execution_count": null,
    "metadata": {
     "editable": true,
     "slideshow": {
@@ -1151,34 +815,15 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 21,
+   "execution_count": null,
    "metadata": {
     "editable": true,
-    "scrolled": true,
     "slideshow": {
      "slide_type": ""
     },
     "tags": []
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "\u001b[92m→\u001b[0m returning existing artifact with same hash: Artifact(uid='nelDyBfwvEIIAKcC0000', is_latest=True, key='vitessce_examples/visium.sdata.zarr', description='Visium SpatialData Example', suffix='.zarr', type='dataset', size=1473180201, hash='BkflAMTiin88wE3Wc84rDQ', n_objects=9167, _hash_type='md5-d', visibility=1, _key_is_virtual=True, storage_id=1, transform_id=17, run_id=79, created_by_id=2, created_at=2024-12-04 13:25:22 UTC)\n"
-     ]
-    },
-    {
-     "data": {
-      "text/plain": [
-       "Artifact(uid='nelDyBfwvEIIAKcC0000', is_latest=True, key='vitessce_examples/visium.sdata.zarr', description='Visium SpatialData Example', suffix='.zarr', type='dataset', size=1473180201, hash='BkflAMTiin88wE3Wc84rDQ', n_objects=9167, _hash_type='md5-d', visibility=1, _key_is_virtual=True, storage_id=1, transform_id=18, run_id=85, created_by_id=2, created_at=2024-12-04 13:25:22 UTC)"
-      ]
-     },
-     "execution_count": 21,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "sdata_zarr_artifact = ln.Artifact(\n",
     "    sdata_zarr_filepath,\n",
@@ -1218,7 +863,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 22,
+   "execution_count": null,
    "metadata": {
     "editable": true,
     "slideshow": {
@@ -1283,7 +928,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 23,
+   "execution_count": null,
    "metadata": {
     "editable": true,
     "slideshow": {
@@ -1293,19 +938,7 @@
      "hide-output"
     ]
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "\u001b[92m→\u001b[0m VitessceConfig references these artifacts:\n",
-      "Artifact(uid='nelDyBfwvEIIAKcC0000', is_latest=True, key='vitessce_examples/visium.sdata.zarr', description='Visium SpatialData Example', suffix='.zarr', type='dataset', size=1473180201, hash='BkflAMTiin88wE3Wc84rDQ', n_objects=9167, _hash_type='md5-d', visibility=1, _key_is_virtual=True, storage_id=1, transform_id=18, run_id=85, created_by_id=2, created_at=2024-12-04 13:25:22 UTC)\n",
-      "\u001b[92m→\u001b[0m returning existing artifact with same hash: Artifact(uid='Xot2a5ZAcTW3fClG0000', is_latest=True, description='View Visium SpatialData Example in Vitessce', suffix='.vitessce.json', size=1845, hash='PirnTDMPxYDC9ajti_St4g', _hash_type='md5', visibility=1, _key_is_virtual=True, storage_id=1, transform_id=15, run_id=82, created_by_id=2, created_at=2024-12-04 15:53:06 UTC)\n",
-      "\u001b[92m→\u001b[0m VitessceConfig: https://lamin.ai/vitessce/examples/artifact/Xot2a5ZAcTW3fClG0000\n",
-      "\u001b[92m→\u001b[0m Dataset: https://lamin.ai/vitessce/examples/artifact/nelDyBfwvEIIAKcC0000\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "sdata_vc_artifact = ln.integrations.save_vitessce_config(\n",
     "    vc, description=\"View Visium SpatialData Example in Vitessce\",\n",
@@ -1314,7 +947,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 24,
+   "execution_count": null,
    "metadata": {
     "editable": true,
     "slideshow": {
@@ -1322,137 +955,7 @@
     },
     "tags": []
    },
-   "outputs": [
-    {
-     "data": {
-      "image/svg+xml": [
-       "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"no\"?>\n",
-       "<!DOCTYPE svg PUBLIC \"-//W3C//DTD SVG 1.1//EN\"\n",
-       " \"http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd\">\n",
-       "<!-- Generated by graphviz version 2.40.1 (20161225.0304)\n",
-       " -->\n",
-       "<!-- Title: artifact_Xot2a5ZAcTW3fClG0000 Pages: 1 -->\n",
-       "<svg width=\"1194pt\" height=\"288pt\"\n",
-       " viewBox=\"0.00 0.00 1194.48 288.00\" xmlns=\"http://www.w3.org/2000/svg\" xmlns:xlink=\"http://www.w3.org/1999/xlink\">\n",
-       "<g id=\"graph0\" class=\"graph\" transform=\"scale(1 1) rotate(0) translate(4 284)\">\n",
-       "<title>artifact_Xot2a5ZAcTW3fClG0000</title>\n",
-       "<polygon fill=\"#ffffff\" stroke=\"transparent\" points=\"-4,4 -4,-284 1190.4761,-284 1190.4761,4 -4,4\"/>\n",
-       "<!-- artifact_nelDyBfwvEIIAKcC0000 -->\n",
-       "<g id=\"node1\" class=\"node\">\n",
-       "<title>artifact_nelDyBfwvEIIAKcC0000</title>\n",
-       "<path fill=\"#f0fff0\" stroke=\"#065f46\" d=\"M183.2717,-196C183.2717,-196 49.7323,-196 49.7323,-196 43.7323,-196 37.7323,-190 37.7323,-184 37.7323,-184 37.7323,-170 37.7323,-170 37.7323,-164 43.7323,-158 49.7323,-158 49.7323,-158 183.2717,-158 183.2717,-158 189.2717,-158 195.2717,-164 195.2717,-170 195.2717,-170 195.2717,-184 195.2717,-184 195.2717,-190 189.2717,-196 183.2717,-196\"/>\n",
-       "<text text-anchor=\"start\" x=\"45.6172\" y=\"-185\" font-family=\"Helvetica,sans-Serif\" font-size=\"10.00\" fill=\"#000000\">📄 Visium SpatialData Example</text>\n",
-       "<text text-anchor=\"start\" x=\"53.2744\" y=\"-175\" font-family=\"Monospace\" font-size=\"10.00\" fill=\"#c0c0c0\">uid=nelDyBfwvEIIAKcC0000</text>\n",
-       "<text text-anchor=\"start\" x=\"91.9121\" y=\"-165\" font-family=\"Monospace\" font-size=\"10.00\" fill=\"#c0c0c0\">suffix=.zarr</text>\n",
-       "</g>\n",
-       "<!-- run_8rJ3LFQ1zd5gJLiWRXGV -->\n",
-       "<g id=\"node2\" class=\"node\">\n",
-       "<title>run_8rJ3LFQ1zd5gJLiWRXGV</title>\n",
-       "<path fill=\"#dcdcdc\" stroke=\"#065f46\" d=\"M180.2444,-122C180.2444,-122 52.7595,-122 52.7595,-122 46.7595,-122 40.7595,-116 40.7595,-110 40.7595,-110 40.7595,-86 40.7595,-86 40.7595,-80 46.7595,-74 52.7595,-74 52.7595,-74 180.2444,-74 180.2444,-74 186.2444,-74 192.2444,-80 192.2444,-86 192.2444,-86 192.2444,-110 192.2444,-110 192.2444,-116 186.2444,-122 180.2444,-122\"/>\n",
-       "<text text-anchor=\"start\" x=\"61.0859\" y=\"-111\" font-family=\"Helvetica,sans-Serif\" font-size=\"10.00\" fill=\"#000000\">🔧 save_vitessce_config</text>\n",
-       "<text text-anchor=\"start\" x=\"62.5273\" y=\"-101\" font-family=\"Monospace\" font-size=\"10.00\" fill=\"#c0c0c0\">uid=kup03MJBsIVa0002</text>\n",
-       "<text text-anchor=\"start\" x=\"52.3003\" y=\"-91\" font-family=\"Monospace\" font-size=\"10.00\" fill=\"#c0c0c0\">type=function, user=mkeller7</text>\n",
-       "<text text-anchor=\"start\" x=\"48.6309\" y=\"-81\" font-family=\"Monospace\" font-size=\"10.00\" fill=\"#c0c0c0\">run=2024&#45;12&#45;04 16:11:34 UTC</text>\n",
-       "</g>\n",
-       "<!-- artifact_nelDyBfwvEIIAKcC0000&#45;&gt;run_8rJ3LFQ1zd5gJLiWRXGV -->\n",
-       "<g id=\"edge1\" class=\"edge\">\n",
-       "<title>artifact_nelDyBfwvEIIAKcC0000&#45;&gt;run_8rJ3LFQ1zd5gJLiWRXGV</title>\n",
-       "<path fill=\"none\" stroke=\"#696969\" d=\"M116.502,-157.8763C116.502,-148.6991 116.502,-137.5013 116.502,-127.2829\"/>\n",
-       "<polygon fill=\"#696969\" stroke=\"#696969\" points=\"118.252,-127.0445 116.502,-122.0445 114.752,-127.0445 118.252,-127.0445\"/>\n",
-       "</g>\n",
-       "<!-- artifact_Xot2a5ZAcTW3fClG0000 -->\n",
-       "<g id=\"node3\" class=\"node\">\n",
-       "<title>artifact_Xot2a5ZAcTW3fClG0000</title>\n",
-       "<path fill=\"#10b981\" stroke=\"#065f46\" d=\"M221.0059,-38C221.0059,-38 11.998,-38 11.998,-38 5.998,-38 -.002,-32 -.002,-26 -.002,-26 -.002,-12 -.002,-12 -.002,-6 5.998,0 11.998,0 11.998,0 221.0059,0 221.0059,0 227.0059,0 233.0059,-6 233.0059,-12 233.0059,-12 233.0059,-26 233.0059,-26 233.0059,-32 227.0059,-38 221.0059,-38\"/>\n",
-       "<text text-anchor=\"start\" x=\"8\" y=\"-27\" font-family=\"Helvetica,sans-Serif\" font-size=\"10.00\" fill=\"#000000\">📄 View Visium SpatialData Example in Vitessce</text>\n",
-       "<text text-anchor=\"start\" x=\"50.4961\" y=\"-17\" font-family=\"Monospace\" font-size=\"10.00\" fill=\"#c0c0c0\">uid=Xot2a5ZAcTW3fClG0000</text>\n",
-       "<text text-anchor=\"start\" x=\"71.8999\" y=\"-7\" font-family=\"Monospace\" font-size=\"10.00\" fill=\"#c0c0c0\">suffix=.vitessce.json</text>\n",
-       "</g>\n",
-       "<!-- run_8rJ3LFQ1zd5gJLiWRXGV&#45;&gt;artifact_Xot2a5ZAcTW3fClG0000 -->\n",
-       "<g id=\"edge2\" class=\"edge\">\n",
-       "<title>run_8rJ3LFQ1zd5gJLiWRXGV&#45;&gt;artifact_Xot2a5ZAcTW3fClG0000</title>\n",
-       "<path fill=\"none\" stroke=\"#696969\" d=\"M116.502,-73.8681C116.502,-64.2201 116.502,-53.1228 116.502,-43.4439\"/>\n",
-       "<polygon fill=\"#696969\" stroke=\"#696969\" points=\"118.252,-43.2308 116.502,-38.2309 114.752,-43.2309 118.252,-43.2308\"/>\n",
-       "</g>\n",
-       "<!-- run_wW6GOHDq44lbrdKi08cr -->\n",
-       "<g id=\"node4\" class=\"node\">\n",
-       "<title>run_wW6GOHDq44lbrdKi08cr</title>\n",
-       "<path fill=\"#dcdcdc\" stroke=\"#065f46\" d=\"M669.9822,-280C669.9822,-280 541.0217,-280 541.0217,-280 535.0217,-280 529.0217,-274 529.0217,-268 529.0217,-268 529.0217,-244 529.0217,-244 529.0217,-238 535.0217,-232 541.0217,-232 541.0217,-232 669.9822,-232 669.9822,-232 675.9822,-232 681.9822,-238 681.9822,-244 681.9822,-244 681.9822,-268 681.9822,-268 681.9822,-274 675.9822,-280 669.9822,-280\"/>\n",
-       "<text text-anchor=\"start\" x=\"578.8042\" y=\"-269\" font-family=\"Helvetica,sans-Serif\" font-size=\"10.00\" fill=\"#000000\">📔 Vitessce</text>\n",
-       "<text text-anchor=\"start\" x=\"549.2227\" y=\"-259\" font-family=\"Monospace\" font-size=\"10.00\" fill=\"#c0c0c0\">uid=BZhZQ6uIbkWv0000</text>\n",
-       "<text text-anchor=\"start\" x=\"538.2388\" y=\"-249\" font-family=\"Monospace\" font-size=\"10.00\" fill=\"#c0c0c0\">type=notebook, user=mkeller7</text>\n",
-       "<text text-anchor=\"start\" x=\"537.2622\" y=\"-239\" font-family=\"Monospace\" font-size=\"10.00\" fill=\"#c0c0c0\">run=2024&#45;12&#45;04 16:10:55 UTC</text>\n",
-       "</g>\n",
-       "<!-- run_wW6GOHDq44lbrdKi08cr&#45;&gt;artifact_nelDyBfwvEIIAKcC0000 -->\n",
-       "<g id=\"edge5\" class=\"edge\">\n",
-       "<title>run_wW6GOHDq44lbrdKi08cr&#45;&gt;artifact_nelDyBfwvEIIAKcC0000</title>\n",
-       "<path fill=\"none\" stroke=\"#696969\" d=\"M529.1332,-246.057C448.2745,-235.1829 317.0306,-216.5447 204.502,-196 203.2239,-195.7667 201.936,-195.5284 200.6403,-195.2859\"/>\n",
-       "<polygon fill=\"#696969\" stroke=\"#696969\" points=\"200.847,-193.5439 195.6082,-194.3302 200.1938,-196.9825 200.847,-193.5439\"/>\n",
-       "</g>\n",
-       "<!-- artifact_1g3a41z0hggWNBrk0000 -->\n",
-       "<g id=\"node5\" class=\"node\">\n",
-       "<title>artifact_1g3a41z0hggWNBrk0000</title>\n",
-       "<path fill=\"#f0fff0\" stroke=\"#065f46\" d=\"M413.3975,-196C413.3975,-196 225.6064,-196 225.6064,-196 219.6064,-196 213.6064,-190 213.6064,-184 213.6064,-184 213.6064,-170 213.6064,-170 213.6064,-164 219.6064,-158 225.6064,-158 225.6064,-158 413.3975,-158 413.3975,-158 419.3975,-158 425.3975,-164 425.3975,-170 425.3975,-170 425.3975,-184 425.3975,-184 425.3975,-190 419.3975,-196 413.3975,-196\"/>\n",
-       "<text text-anchor=\"start\" x=\"221.5542\" y=\"-185\" font-family=\"Helvetica,sans-Serif\" font-size=\"10.00\" fill=\"#000000\">📄 Habib et al., 2017 Nature Methods, h5ad</text>\n",
-       "<text text-anchor=\"start\" x=\"252.6489\" y=\"-175\" font-family=\"Monospace\" font-size=\"10.00\" fill=\"#c0c0c0\">uid=1g3a41z0hggWNBrk0000</text>\n",
-       "<text text-anchor=\"start\" x=\"292.3999\" y=\"-165\" font-family=\"Monospace\" font-size=\"10.00\" fill=\"#c0c0c0\">suffix=.h5ad</text>\n",
-       "</g>\n",
-       "<!-- run_wW6GOHDq44lbrdKi08cr&#45;&gt;artifact_1g3a41z0hggWNBrk0000 -->\n",
-       "<g id=\"edge3\" class=\"edge\">\n",
-       "<title>run_wW6GOHDq44lbrdKi08cr&#45;&gt;artifact_1g3a41z0hggWNBrk0000</title>\n",
-       "<path fill=\"none\" stroke=\"#696969\" d=\"M529.2349,-234.9332C487.2559,-223.3376 435.3865,-209.0101 393.7337,-197.5046\"/>\n",
-       "<polygon fill=\"#696969\" stroke=\"#696969\" points=\"393.9916,-195.7603 388.7061,-196.1158 393.0596,-199.134 393.9916,-195.7603\"/>\n",
-       "</g>\n",
-       "<!-- artifact_O7CTVi6XjnfsceQ20000 -->\n",
-       "<g id=\"node6\" class=\"node\">\n",
-       "<title>artifact_O7CTVi6XjnfsceQ20000</title>\n",
-       "<path fill=\"#f0fff0\" stroke=\"#065f46\" d=\"M755.7003,-196C755.7003,-196 455.3036,-196 455.3036,-196 449.3036,-196 443.3036,-190 443.3036,-184 443.3036,-184 443.3036,-170 443.3036,-170 443.3036,-164 449.3036,-158 455.3036,-158 455.3036,-158 755.7003,-158 755.7003,-158 761.7003,-158 767.7003,-164 767.7003,-170 767.7003,-170 767.7003,-184 767.7003,-184 767.7003,-190 761.7003,-196 755.7003,-196\"/>\n",
-       "<text text-anchor=\"start\" x=\"451.1528\" y=\"-185\" font-family=\"Helvetica,sans-Serif\" font-size=\"10.00\" fill=\"#000000\">📄 Reference JSON for H5AD file, Habib et al., 2017 Nature Methods</text>\n",
-       "<text text-anchor=\"start\" x=\"541.2466\" y=\"-175\" font-family=\"Monospace\" font-size=\"10.00\" fill=\"#c0c0c0\">uid=O7CTVi6XjnfsceQ20000</text>\n",
-       "<text text-anchor=\"start\" x=\"580.3506\" y=\"-165\" font-family=\"Monospace\" font-size=\"10.00\" fill=\"#c0c0c0\">suffix=.json</text>\n",
-       "</g>\n",
-       "<!-- run_wW6GOHDq44lbrdKi08cr&#45;&gt;artifact_O7CTVi6XjnfsceQ20000 -->\n",
-       "<g id=\"edge4\" class=\"edge\">\n",
-       "<title>run_wW6GOHDq44lbrdKi08cr&#45;&gt;artifact_O7CTVi6XjnfsceQ20000</title>\n",
-       "<path fill=\"none\" stroke=\"#696969\" d=\"M605.502,-231.8681C605.502,-222.2201 605.502,-211.1228 605.502,-201.4439\"/>\n",
-       "<polygon fill=\"#696969\" stroke=\"#696969\" points=\"607.252,-201.2308 605.502,-196.2309 603.752,-201.2309 607.252,-201.2308\"/>\n",
-       "</g>\n",
-       "<!-- artifact_kWwG45Hr26KZUW3g0004 -->\n",
-       "<g id=\"node7\" class=\"node\">\n",
-       "<title>artifact_kWwG45Hr26KZUW3g0004</title>\n",
-       "<path fill=\"#f0fff0\" stroke=\"#065f46\" d=\"M980.8731,-196C980.8731,-196 798.1308,-196 798.1308,-196 792.1308,-196 786.1308,-190 786.1308,-184 786.1308,-184 786.1308,-170 786.1308,-170 786.1308,-164 792.1308,-158 798.1308,-158 798.1308,-158 980.8731,-158 980.8731,-158 986.8731,-158 992.8731,-164 992.8731,-170 992.8731,-170 992.8731,-184 992.8731,-184 992.8731,-190 986.8731,-196 980.8731,-196\"/>\n",
-       "<text text-anchor=\"start\" x=\"794.0664\" y=\"-185\" font-family=\"Helvetica,sans-Serif\" font-size=\"10.00\" fill=\"#000000\">📄 Habib et al., 2017 Nature Methods, zarr</text>\n",
-       "<text text-anchor=\"start\" x=\"817.3877\" y=\"-175\" font-family=\"Monospace\" font-size=\"10.00\" fill=\"#c0c0c0\">uid=kWwG45Hr26KZUW3g0004</text>\n",
-       "<text text-anchor=\"start\" x=\"845.4492\" y=\"-165\" font-family=\"Monospace\" font-size=\"10.00\" fill=\"#c0c0c0\">suffix=.anndata.zarr</text>\n",
-       "</g>\n",
-       "<!-- run_wW6GOHDq44lbrdKi08cr&#45;&gt;artifact_kWwG45Hr26KZUW3g0004 -->\n",
-       "<g id=\"edge6\" class=\"edge\">\n",
-       "<title>run_wW6GOHDq44lbrdKi08cr&#45;&gt;artifact_kWwG45Hr26KZUW3g0004</title>\n",
-       "<path fill=\"none\" stroke=\"#696969\" d=\"M681.9823,-234.7255C723.6607,-223.1319 774.984,-208.8553 816.1623,-197.4008\"/>\n",
-       "<polygon fill=\"#696969\" stroke=\"#696969\" points=\"816.7843,-199.0443 821.1324,-196.0183 815.8463,-195.6723 816.7843,-199.0443\"/>\n",
-       "</g>\n",
-       "<!-- collection_obXokdzOnSH2tytJ0000 -->\n",
-       "<g id=\"node8\" class=\"node\">\n",
-       "<title>collection_obXokdzOnSH2tytJ0000</title>\n",
-       "<path fill=\"#f0fff0\" stroke=\"#065f46\" d=\"M1174.4502,-196C1174.4502,-196 1022.5537,-196 1022.5537,-196 1016.5537,-196 1010.5537,-190 1010.5537,-184 1010.5537,-184 1010.5537,-170 1010.5537,-170 1010.5537,-164 1016.5537,-158 1022.5537,-158 1022.5537,-158 1174.4502,-158 1174.4502,-158 1180.4502,-158 1186.4502,-164 1186.4502,-170 1186.4502,-170 1186.4502,-184 1186.4502,-184 1186.4502,-190 1180.4502,-196 1174.4502,-196\"/>\n",
-       "<text text-anchor=\"start\" x=\"1018.5278\" y=\"-185\" font-family=\"Helvetica,sans-Serif\" font-size=\"10.00\" fill=\"#000000\">🍱 View Habib17 (h5ad) in Vitessce</text>\n",
-       "<text text-anchor=\"start\" x=\"1034.1538\" y=\"-175\" font-family=\"Monospace\" font-size=\"10.00\" fill=\"#c0c0c0\">uid=obXokdzOnSH2tytJ0000</text>\n",
-       "<text text-anchor=\"start\" x=\"1067.5107\" y=\"-165\" font-family=\"Monospace\" font-size=\"10.00\" fill=\"#c0c0c0\">version=None</text>\n",
-       "</g>\n",
-       "<!-- run_wW6GOHDq44lbrdKi08cr&#45;&gt;collection_obXokdzOnSH2tytJ0000 -->\n",
-       "<g id=\"edge7\" class=\"edge\">\n",
-       "<title>run_wW6GOHDq44lbrdKi08cr&#45;&gt;collection_obXokdzOnSH2tytJ0000</title>\n",
-       "<path fill=\"none\" stroke=\"#696969\" d=\"M681.9452,-245.4134C761.8162,-234.1191 890.6873,-215.2388 1001.502,-196 1002.7964,-195.7753 1004.1002,-195.547 1005.4116,-195.3155\"/>\n",
-       "<polygon fill=\"#696969\" stroke=\"#696969\" points=\"1005.8886,-197.0082 1010.5041,-194.4082 1005.2746,-193.5625 1005.8886,-197.0082\"/>\n",
-       "</g>\n",
-       "</g>\n",
-       "</svg>\n"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    }
-   ],
+   "outputs": [],
    "source": [
     "sdata_vc_artifact.view_lineage()"
    ]
@@ -1515,7 +1018,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 25,
+   "execution_count": null,
    "metadata": {
     "editable": true,
     "slideshow": {
@@ -1561,7 +1064,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 26,
+   "execution_count": null,
    "metadata": {
     "editable": true,
     "slideshow": {
@@ -1569,25 +1072,7 @@
     },
     "tags": []
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "\u001b[92m→\u001b[0m returning existing artifact with same hash: Artifact(uid='0I5aMNdh2UrECtFX0000', is_latest=True, key='vitessce_examples/VAN0006-LK-2-85-PAS_registered.ome.tif', description='PAS OME-TIFF file, Neumann et al., 2020', suffix='.tif', type='dataset', size=1021561156, hash='pa3FYqKL6afG8PduprhRJk', _hash_type='sha1-fl', visibility=1, _key_is_virtual=True, storage_id=1, transform_id=17, run_id=79, created_by_id=2, created_at=2024-10-05 20:00:49 UTC)\n"
-     ]
-    },
-    {
-     "data": {
-      "text/plain": [
-       "Artifact(uid='0I5aMNdh2UrECtFX0000', is_latest=True, key='vitessce_examples/VAN0006-LK-2-85-PAS_registered.ome.tif', description='PAS OME-TIFF file, Neumann et al., 2020', suffix='.tif', type='dataset', size=1021561156, hash='pa3FYqKL6afG8PduprhRJk', _hash_type='sha1-fl', visibility=1, _key_is_virtual=True, storage_id=1, transform_id=18, run_id=85, created_by_id=2, created_at=2024-10-05 20:00:49 UTC)"
-      ]
-     },
-     "execution_count": 26,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "ome_tiff_artifact = ln.Artifact(\n",
     "    ome_tiff_filepath,\n",
@@ -1613,7 +1098,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 27,
+   "execution_count": null,
    "metadata": {
     "editable": true,
     "slideshow": {
@@ -1628,7 +1113,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 28,
+   "execution_count": null,
    "metadata": {
     "editable": true,
     "slideshow": {
@@ -1636,15 +1121,7 @@
     },
     "tags": []
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "\u001b[92m→\u001b[0m returning existing artifact with same hash: Artifact(uid='CMBUzbNNCEDGCKcQ0000', is_latest=True, key='vitessce_examples/VAN0006-LK-2-85-PAS_registered.offsets.json', description='PAS offsets file, Neumann et al., 2020', suffix='.json', type='dataset', size=36, hash='5ADv5d7DI5oYVaMOPnhqiw', _hash_type='md5', visibility=1, _key_is_virtual=True, storage_id=1, transform_id=17, run_id=79, created_by_id=2, created_at=2024-10-05 20:18:38 UTC)\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "offsets_path = \"./VAN0006-LK-2-85-PAS_registered.offsets.json\"\n",
     "with open(offsets_path, \"w\") as file:\n",
@@ -1685,7 +1162,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 29,
+   "execution_count": null,
    "metadata": {
     "editable": true,
     "slideshow": {
@@ -1725,7 +1202,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 30,
+   "execution_count": null,
    "metadata": {
     "editable": true,
     "slideshow": {
@@ -1735,21 +1212,7 @@
      "hide-output"
     ]
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "\u001b[92m→\u001b[0m VitessceConfig references these artifacts:\n",
-      "Artifact(uid='0I5aMNdh2UrECtFX0000', is_latest=True, key='vitessce_examples/VAN0006-LK-2-85-PAS_registered.ome.tif', description='PAS OME-TIFF file, Neumann et al., 2020', suffix='.tif', type='dataset', size=1021561156, hash='pa3FYqKL6afG8PduprhRJk', _hash_type='sha1-fl', visibility=1, _key_is_virtual=True, storage_id=1, transform_id=18, run_id=85, created_by_id=2, created_at=2024-10-05 20:00:49 UTC)\n",
-      "Artifact(uid='CMBUzbNNCEDGCKcQ0000', is_latest=True, key='vitessce_examples/VAN0006-LK-2-85-PAS_registered.offsets.json', description='PAS offsets file, Neumann et al., 2020', suffix='.json', type='dataset', size=36, hash='5ADv5d7DI5oYVaMOPnhqiw', _hash_type='md5', visibility=1, _key_is_virtual=True, storage_id=1, transform_id=18, run_id=85, created_by_id=2, created_at=2024-10-05 20:18:38 UTC)\n",
-      "\u001b[93m!\u001b[0m returning existing collection with same hash: Collection(uid='HqfzZmkfYOy20ZNN0000', is_latest=True, name='View PAS OME-TIFF, Neumann et al., 2020 in Vitessce', hash='vpleElXxZiaZblQ09q9K-g', visibility=1, created_by_id=2, transform_id=17, run_id=79, created_at=2024-10-05 20:49:25 UTC)\n",
-      "\u001b[92m→\u001b[0m returning existing artifact with same hash: Artifact(uid='QtF1OEtYyUe1EQ1k0000', is_latest=True, description='View PAS OME-TIFF, Neumann et al., 2020 in Vitessce', suffix='.vitessce.json', size=724, hash='SzO9Fq5iH2Xhz76j-qTjvg', _hash_type='md5', visibility=1, _key_is_virtual=True, storage_id=1, transform_id=15, run_id=83, created_by_id=2, created_at=2024-12-04 14:34:20 UTC)\n",
-      "\u001b[92m→\u001b[0m VitessceConfig: https://lamin.ai/vitessce/examples/artifact/QtF1OEtYyUe1EQ1k0000\n",
-      "\u001b[92m→\u001b[0m Collection: https://lamin.ai/vitessce/examples/collection/HqfzZmkfYOy20ZNN0000\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "ome_tiff_vc_artifact = ln.integrations.save_vitessce_config(\n",
     "    vc, description=\"View PAS OME-TIFF, Neumann et al., 2020 in Vitessce\",\n",
@@ -1758,7 +1221,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 31,
+   "execution_count": null,
    "metadata": {
     "editable": true,
     "slideshow": {
@@ -1766,185 +1229,7 @@
     },
     "tags": []
    },
-   "outputs": [
-    {
-     "data": {
-      "image/svg+xml": [
-       "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"no\"?>\n",
-       "<!DOCTYPE svg PUBLIC \"-//W3C//DTD SVG 1.1//EN\"\n",
-       " \"http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd\">\n",
-       "<!-- Generated by graphviz version 2.40.1 (20161225.0304)\n",
-       " -->\n",
-       "<!-- Title: artifact_QtF1OEtYyUe1EQ1k0000 Pages: 1 -->\n",
-       "<svg width=\"1904pt\" height=\"288pt\"\n",
-       " viewBox=\"0.00 0.00 1904.06 288.00\" xmlns=\"http://www.w3.org/2000/svg\" xmlns:xlink=\"http://www.w3.org/1999/xlink\">\n",
-       "<g id=\"graph0\" class=\"graph\" transform=\"scale(1 1) rotate(0) translate(4 284)\">\n",
-       "<title>artifact_QtF1OEtYyUe1EQ1k0000</title>\n",
-       "<polygon fill=\"#ffffff\" stroke=\"transparent\" points=\"-4,4 -4,-284 1900.0615,-284 1900.0615,4 -4,4\"/>\n",
-       "<!-- artifact_0I5aMNdh2UrECtFX0000 -->\n",
-       "<g id=\"node1\" class=\"node\">\n",
-       "<title>artifact_0I5aMNdh2UrECtFX0000</title>\n",
-       "<path fill=\"#f0fff0\" stroke=\"#065f46\" d=\"M205.6691,-196C205.6691,-196 12.1102,-196 12.1102,-196 6.1102,-196 .1102,-190 .1102,-184 .1102,-184 .1102,-170 .1102,-170 .1102,-164 6.1102,-158 12.1102,-158 12.1102,-158 205.6691,-158 205.6691,-158 211.6691,-158 217.6691,-164 217.6691,-170 217.6691,-170 217.6691,-184 217.6691,-184 217.6691,-190 211.6691,-196 205.6691,-196\"/>\n",
-       "<text text-anchor=\"start\" x=\"8\" y=\"-185\" font-family=\"Helvetica,sans-Serif\" font-size=\"10.00\" fill=\"#000000\">📄 PAS OME&#45;TIFF file, Neumann et al., 2020</text>\n",
-       "<text text-anchor=\"start\" x=\"42.3247\" y=\"-175\" font-family=\"Monospace\" font-size=\"10.00\" fill=\"#c0c0c0\">uid=0I5aMNdh2UrECtFX0000</text>\n",
-       "<text text-anchor=\"start\" x=\"89.0215\" y=\"-165\" font-family=\"Monospace\" font-size=\"10.00\" fill=\"#c0c0c0\">suffix=.tif</text>\n",
-       "</g>\n",
-       "<!-- run_PWGWyCcRk4ZAUWxNBeiJ -->\n",
-       "<g id=\"node2\" class=\"node\">\n",
-       "<title>run_PWGWyCcRk4ZAUWxNBeiJ</title>\n",
-       "<path fill=\"#dcdcdc\" stroke=\"#065f46\" d=\"M285.6321,-122C285.6321,-122 158.1472,-122 158.1472,-122 152.1472,-122 146.1472,-116 146.1472,-110 146.1472,-110 146.1472,-86 146.1472,-86 146.1472,-80 152.1472,-74 158.1472,-74 158.1472,-74 285.6321,-74 285.6321,-74 291.6321,-74 297.6321,-80 297.6321,-86 297.6321,-86 297.6321,-110 297.6321,-110 297.6321,-116 291.6321,-122 285.6321,-122\"/>\n",
-       "<text text-anchor=\"start\" x=\"166.4736\" y=\"-111\" font-family=\"Helvetica,sans-Serif\" font-size=\"10.00\" fill=\"#000000\">🔧 save_vitessce_config</text>\n",
-       "<text text-anchor=\"start\" x=\"167.915\" y=\"-101\" font-family=\"Monospace\" font-size=\"10.00\" fill=\"#c0c0c0\">uid=kup03MJBsIVa0002</text>\n",
-       "<text text-anchor=\"start\" x=\"157.688\" y=\"-91\" font-family=\"Monospace\" font-size=\"10.00\" fill=\"#c0c0c0\">type=function, user=mkeller7</text>\n",
-       "<text text-anchor=\"start\" x=\"154.0186\" y=\"-81\" font-family=\"Monospace\" font-size=\"10.00\" fill=\"#c0c0c0\">run=2024&#45;12&#45;04 16:11:43 UTC</text>\n",
-       "</g>\n",
-       "<!-- artifact_0I5aMNdh2UrECtFX0000&#45;&gt;run_PWGWyCcRk4ZAUWxNBeiJ -->\n",
-       "<g id=\"edge1\" class=\"edge\">\n",
-       "<title>artifact_0I5aMNdh2UrECtFX0000&#45;&gt;run_PWGWyCcRk4ZAUWxNBeiJ</title>\n",
-       "<path fill=\"none\" stroke=\"#696969\" d=\"M136.2438,-157.8763C150.3341,-148.0256 167.7546,-135.8466 183.1979,-125.05\"/>\n",
-       "<polygon fill=\"#696969\" stroke=\"#696969\" points=\"184.4017,-126.3437 187.4969,-122.0445 182.3963,-123.4752 184.4017,-126.3437\"/>\n",
-       "</g>\n",
-       "<!-- artifact_QtF1OEtYyUe1EQ1k0000 -->\n",
-       "<g id=\"node4\" class=\"node\">\n",
-       "<title>artifact_QtF1OEtYyUe1EQ1k0000</title>\n",
-       "<path fill=\"#10b981\" stroke=\"#065f46\" d=\"M348.2336,-38C348.2336,-38 95.5457,-38 95.5457,-38 89.5457,-38 83.5457,-32 83.5457,-26 83.5457,-26 83.5457,-12 83.5457,-12 83.5457,-6 89.5457,0 95.5457,0 95.5457,0 348.2336,0 348.2336,0 354.2336,0 360.2336,-6 360.2336,-12 360.2336,-12 360.2336,-26 360.2336,-26 360.2336,-32 354.2336,-38 348.2336,-38\"/>\n",
-       "<text text-anchor=\"start\" x=\"91.7178\" y=\"-27\" font-family=\"Helvetica,sans-Serif\" font-size=\"10.00\" fill=\"#000000\">📄 View PAS OME&#45;TIFF, Neumann et al., 2020 in Vitessce</text>\n",
-       "<text text-anchor=\"start\" x=\"153.9355\" y=\"-17\" font-family=\"Monospace\" font-size=\"10.00\" fill=\"#c0c0c0\">uid=QtF1OEtYyUe1EQ1k0000</text>\n",
-       "<text text-anchor=\"start\" x=\"177.2876\" y=\"-7\" font-family=\"Monospace\" font-size=\"10.00\" fill=\"#c0c0c0\">suffix=.vitessce.json</text>\n",
-       "</g>\n",
-       "<!-- run_PWGWyCcRk4ZAUWxNBeiJ&#45;&gt;artifact_QtF1OEtYyUe1EQ1k0000 -->\n",
-       "<g id=\"edge3\" class=\"edge\">\n",
-       "<title>run_PWGWyCcRk4ZAUWxNBeiJ&#45;&gt;artifact_QtF1OEtYyUe1EQ1k0000</title>\n",
-       "<path fill=\"none\" stroke=\"#696969\" d=\"M221.8896,-73.8681C221.8896,-64.2201 221.8896,-53.1228 221.8896,-43.4439\"/>\n",
-       "<polygon fill=\"#696969\" stroke=\"#696969\" points=\"223.6397,-43.2308 221.8896,-38.2309 220.1397,-43.2309 223.6397,-43.2308\"/>\n",
-       "</g>\n",
-       "<!-- artifact_CMBUzbNNCEDGCKcQ0000 -->\n",
-       "<g id=\"node3\" class=\"node\">\n",
-       "<title>artifact_CMBUzbNNCEDGCKcQ0000</title>\n",
-       "<path fill=\"#f0fff0\" stroke=\"#065f46\" d=\"M423.7393,-196C423.7393,-196 248.04,-196 248.04,-196 242.04,-196 236.04,-190 236.04,-184 236.04,-184 236.04,-170 236.04,-170 236.04,-164 242.04,-158 248.04,-158 248.04,-158 423.7393,-158 423.7393,-158 429.7393,-158 435.7393,-164 435.7393,-170 435.7393,-170 435.7393,-184 435.7393,-184 435.7393,-190 429.7393,-196 423.7393,-196\"/>\n",
-       "<text text-anchor=\"start\" x=\"243.9648\" y=\"-185\" font-family=\"Helvetica,sans-Serif\" font-size=\"10.00\" fill=\"#000000\">📄 PAS offsets file, Neumann et al., 2020</text>\n",
-       "<text text-anchor=\"start\" x=\"260.1694\" y=\"-175\" font-family=\"Monospace\" font-size=\"10.00\" fill=\"#c0c0c0\">uid=CMBUzbNNCEDGCKcQ0000</text>\n",
-       "<text text-anchor=\"start\" x=\"310.7383\" y=\"-165\" font-family=\"Monospace\" font-size=\"10.00\" fill=\"#c0c0c0\">suffix=.json</text>\n",
-       "</g>\n",
-       "<!-- artifact_CMBUzbNNCEDGCKcQ0000&#45;&gt;run_PWGWyCcRk4ZAUWxNBeiJ -->\n",
-       "<g id=\"edge2\" class=\"edge\">\n",
-       "<title>artifact_CMBUzbNNCEDGCKcQ0000&#45;&gt;run_PWGWyCcRk4ZAUWxNBeiJ</title>\n",
-       "<path fill=\"none\" stroke=\"#696969\" d=\"M308.2934,-157.8763C294.0785,-148.0256 276.5038,-135.8466 260.9238,-125.05\"/>\n",
-       "<polygon fill=\"#696969\" stroke=\"#696969\" points=\"261.6933,-123.4541 256.5868,-122.0445 259.6997,-126.3309 261.6933,-123.4541\"/>\n",
-       "</g>\n",
-       "<!-- run_wW6GOHDq44lbrdKi08cr -->\n",
-       "<g id=\"node5\" class=\"node\">\n",
-       "<title>run_wW6GOHDq44lbrdKi08cr</title>\n",
-       "<path fill=\"#dcdcdc\" stroke=\"#065f46\" d=\"M1039.3699,-280C1039.3699,-280 910.4094,-280 910.4094,-280 904.4094,-280 898.4094,-274 898.4094,-268 898.4094,-268 898.4094,-244 898.4094,-244 898.4094,-238 904.4094,-232 910.4094,-232 910.4094,-232 1039.3699,-232 1039.3699,-232 1045.3699,-232 1051.3699,-238 1051.3699,-244 1051.3699,-244 1051.3699,-268 1051.3699,-268 1051.3699,-274 1045.3699,-280 1039.3699,-280\"/>\n",
-       "<text text-anchor=\"start\" x=\"948.1919\" y=\"-269\" font-family=\"Helvetica,sans-Serif\" font-size=\"10.00\" fill=\"#000000\">📔 Vitessce</text>\n",
-       "<text text-anchor=\"start\" x=\"918.6104\" y=\"-259\" font-family=\"Monospace\" font-size=\"10.00\" fill=\"#c0c0c0\">uid=BZhZQ6uIbkWv0000</text>\n",
-       "<text text-anchor=\"start\" x=\"907.6265\" y=\"-249\" font-family=\"Monospace\" font-size=\"10.00\" fill=\"#c0c0c0\">type=notebook, user=mkeller7</text>\n",
-       "<text text-anchor=\"start\" x=\"906.6499\" y=\"-239\" font-family=\"Monospace\" font-size=\"10.00\" fill=\"#c0c0c0\">run=2024&#45;12&#45;04 16:10:55 UTC</text>\n",
-       "</g>\n",
-       "<!-- run_wW6GOHDq44lbrdKi08cr&#45;&gt;artifact_0I5aMNdh2UrECtFX0000 -->\n",
-       "<g id=\"edge7\" class=\"edge\">\n",
-       "<title>run_wW6GOHDq44lbrdKi08cr&#45;&gt;artifact_0I5aMNdh2UrECtFX0000</title>\n",
-       "<path fill=\"none\" stroke=\"#696969\" d=\"M898.5047,-251.8865C762.9385,-244.1373 471.511,-225.4577 226.8896,-196 225.5828,-195.8426 224.2682,-195.6814 222.9471,-195.5166\"/>\n",
-       "<polygon fill=\"#696969\" stroke=\"#696969\" points=\"223.0029,-193.7596 217.8218,-194.8637 222.5605,-197.2315 223.0029,-193.7596\"/>\n",
-       "</g>\n",
-       "<!-- run_wW6GOHDq44lbrdKi08cr&#45;&gt;artifact_CMBUzbNNCEDGCKcQ0000 -->\n",
-       "<g id=\"edge8\" class=\"edge\">\n",
-       "<title>run_wW6GOHDq44lbrdKi08cr&#45;&gt;artifact_CMBUzbNNCEDGCKcQ0000</title>\n",
-       "<path fill=\"none\" stroke=\"#696969\" d=\"M898.3476,-248.7865C795.1452,-238.7292 605.7547,-219.1048 444.8896,-196 443.6003,-195.8148 442.3027,-195.6261 440.9983,-195.4342\"/>\n",
-       "<polygon fill=\"#696969\" stroke=\"#696969\" points=\"441.1396,-193.686 435.9361,-194.6787 440.623,-197.1476 441.1396,-193.686\"/>\n",
-       "</g>\n",
-       "<!-- artifact_1g3a41z0hggWNBrk0000 -->\n",
-       "<g id=\"node6\" class=\"node\">\n",
-       "<title>artifact_1g3a41z0hggWNBrk0000</title>\n",
-       "<path fill=\"#f0fff0\" stroke=\"#065f46\" d=\"M653.7852,-196C653.7852,-196 465.9941,-196 465.9941,-196 459.9941,-196 453.9941,-190 453.9941,-184 453.9941,-184 453.9941,-170 453.9941,-170 453.9941,-164 459.9941,-158 465.9941,-158 465.9941,-158 653.7852,-158 653.7852,-158 659.7852,-158 665.7852,-164 665.7852,-170 665.7852,-170 665.7852,-184 665.7852,-184 665.7852,-190 659.7852,-196 653.7852,-196\"/>\n",
-       "<text text-anchor=\"start\" x=\"461.9419\" y=\"-185\" font-family=\"Helvetica,sans-Serif\" font-size=\"10.00\" fill=\"#000000\">📄 Habib et al., 2017 Nature Methods, h5ad</text>\n",
-       "<text text-anchor=\"start\" x=\"493.0366\" y=\"-175\" font-family=\"Monospace\" font-size=\"10.00\" fill=\"#c0c0c0\">uid=1g3a41z0hggWNBrk0000</text>\n",
-       "<text text-anchor=\"start\" x=\"532.7876\" y=\"-165\" font-family=\"Monospace\" font-size=\"10.00\" fill=\"#c0c0c0\">suffix=.h5ad</text>\n",
-       "</g>\n",
-       "<!-- run_wW6GOHDq44lbrdKi08cr&#45;&gt;artifact_1g3a41z0hggWNBrk0000 -->\n",
-       "<g id=\"edge4\" class=\"edge\">\n",
-       "<title>run_wW6GOHDq44lbrdKi08cr&#45;&gt;artifact_1g3a41z0hggWNBrk0000</title>\n",
-       "<path fill=\"none\" stroke=\"#696969\" d=\"M898.2886,-241.4181C832.7621,-228.9444 737.7998,-210.8672 665.1394,-197.0355\"/>\n",
-       "<polygon fill=\"#696969\" stroke=\"#696969\" points=\"665.1862,-195.263 659.9471,-196.0471 664.5316,-198.7013 665.1862,-195.263\"/>\n",
-       "</g>\n",
-       "<!-- artifact_O7CTVi6XjnfsceQ20000 -->\n",
-       "<g id=\"node7\" class=\"node\">\n",
-       "<title>artifact_O7CTVi6XjnfsceQ20000</title>\n",
-       "<path fill=\"#f0fff0\" stroke=\"#065f46\" d=\"M996.088,-196C996.088,-196 695.6913,-196 695.6913,-196 689.6913,-196 683.6913,-190 683.6913,-184 683.6913,-184 683.6913,-170 683.6913,-170 683.6913,-164 689.6913,-158 695.6913,-158 695.6913,-158 996.088,-158 996.088,-158 1002.088,-158 1008.088,-164 1008.088,-170 1008.088,-170 1008.088,-184 1008.088,-184 1008.088,-190 1002.088,-196 996.088,-196\"/>\n",
-       "<text text-anchor=\"start\" x=\"691.5405\" y=\"-185\" font-family=\"Helvetica,sans-Serif\" font-size=\"10.00\" fill=\"#000000\">📄 Reference JSON for H5AD file, Habib et al., 2017 Nature Methods</text>\n",
-       "<text text-anchor=\"start\" x=\"781.6343\" y=\"-175\" font-family=\"Monospace\" font-size=\"10.00\" fill=\"#c0c0c0\">uid=O7CTVi6XjnfsceQ20000</text>\n",
-       "<text text-anchor=\"start\" x=\"820.7383\" y=\"-165\" font-family=\"Monospace\" font-size=\"10.00\" fill=\"#c0c0c0\">suffix=.json</text>\n",
-       "</g>\n",
-       "<!-- run_wW6GOHDq44lbrdKi08cr&#45;&gt;artifact_O7CTVi6XjnfsceQ20000 -->\n",
-       "<g id=\"edge5\" class=\"edge\">\n",
-       "<title>run_wW6GOHDq44lbrdKi08cr&#45;&gt;artifact_O7CTVi6XjnfsceQ20000</title>\n",
-       "<path fill=\"none\" stroke=\"#696969\" d=\"M935.4845,-231.8681C918.4172,-221.4161 898.5726,-209.2632 881.9041,-199.0554\"/>\n",
-       "<polygon fill=\"#696969\" stroke=\"#696969\" points=\"882.4699,-197.3498 877.2919,-196.2309 880.642,-200.3346 882.4699,-197.3498\"/>\n",
-       "</g>\n",
-       "<!-- artifact_nelDyBfwvEIIAKcC0000 -->\n",
-       "<g id=\"node8\" class=\"node\">\n",
-       "<title>artifact_nelDyBfwvEIIAKcC0000</title>\n",
-       "<path fill=\"#f0fff0\" stroke=\"#065f46\" d=\"M1171.6593,-196C1171.6593,-196 1038.1199,-196 1038.1199,-196 1032.1199,-196 1026.1199,-190 1026.1199,-184 1026.1199,-184 1026.1199,-170 1026.1199,-170 1026.1199,-164 1032.1199,-158 1038.1199,-158 1038.1199,-158 1171.6593,-158 1171.6593,-158 1177.6593,-158 1183.6593,-164 1183.6593,-170 1183.6593,-170 1183.6593,-184 1183.6593,-184 1183.6593,-190 1177.6593,-196 1171.6593,-196\"/>\n",
-       "<text text-anchor=\"start\" x=\"1034.0049\" y=\"-185\" font-family=\"Helvetica,sans-Serif\" font-size=\"10.00\" fill=\"#000000\">📄 Visium SpatialData Example</text>\n",
-       "<text text-anchor=\"start\" x=\"1041.6621\" y=\"-175\" font-family=\"Monospace\" font-size=\"10.00\" fill=\"#c0c0c0\">uid=nelDyBfwvEIIAKcC0000</text>\n",
-       "<text text-anchor=\"start\" x=\"1080.2998\" y=\"-165\" font-family=\"Monospace\" font-size=\"10.00\" fill=\"#c0c0c0\">suffix=.zarr</text>\n",
-       "</g>\n",
-       "<!-- run_wW6GOHDq44lbrdKi08cr&#45;&gt;artifact_nelDyBfwvEIIAKcC0000 -->\n",
-       "<g id=\"edge6\" class=\"edge\">\n",
-       "<title>run_wW6GOHDq44lbrdKi08cr&#45;&gt;artifact_nelDyBfwvEIIAKcC0000</title>\n",
-       "<path fill=\"none\" stroke=\"#696969\" d=\"M1014.6003,-231.8681C1031.7999,-221.4161 1051.7983,-209.2632 1068.596,-199.0554\"/>\n",
-       "<polygon fill=\"#696969\" stroke=\"#696969\" points=\"1069.8798,-200.323 1073.2439,-196.2309 1068.0622,-197.332 1069.8798,-200.323\"/>\n",
-       "</g>\n",
-       "<!-- artifact_kWwG45Hr26KZUW3g0004 -->\n",
-       "<g id=\"node9\" class=\"node\">\n",
-       "<title>artifact_kWwG45Hr26KZUW3g0004</title>\n",
-       "<path fill=\"#f0fff0\" stroke=\"#065f46\" d=\"M1396.2608,-196C1396.2608,-196 1213.5185,-196 1213.5185,-196 1207.5185,-196 1201.5185,-190 1201.5185,-184 1201.5185,-184 1201.5185,-170 1201.5185,-170 1201.5185,-164 1207.5185,-158 1213.5185,-158 1213.5185,-158 1396.2608,-158 1396.2608,-158 1402.2608,-158 1408.2608,-164 1408.2608,-170 1408.2608,-170 1408.2608,-184 1408.2608,-184 1408.2608,-190 1402.2608,-196 1396.2608,-196\"/>\n",
-       "<text text-anchor=\"start\" x=\"1209.4541\" y=\"-185\" font-family=\"Helvetica,sans-Serif\" font-size=\"10.00\" fill=\"#000000\">📄 Habib et al., 2017 Nature Methods, zarr</text>\n",
-       "<text text-anchor=\"start\" x=\"1232.7754\" y=\"-175\" font-family=\"Monospace\" font-size=\"10.00\" fill=\"#c0c0c0\">uid=kWwG45Hr26KZUW3g0004</text>\n",
-       "<text text-anchor=\"start\" x=\"1260.8369\" y=\"-165\" font-family=\"Monospace\" font-size=\"10.00\" fill=\"#c0c0c0\">suffix=.anndata.zarr</text>\n",
-       "</g>\n",
-       "<!-- run_wW6GOHDq44lbrdKi08cr&#45;&gt;artifact_kWwG45Hr26KZUW3g0004 -->\n",
-       "<g id=\"edge9\" class=\"edge\">\n",
-       "<title>run_wW6GOHDq44lbrdKi08cr&#45;&gt;artifact_kWwG45Hr26KZUW3g0004</title>\n",
-       "<path fill=\"none\" stroke=\"#696969\" d=\"M1051.4277,-237.6772C1101.9673,-225.5784 1168.2277,-209.716 1220.3249,-197.2443\"/>\n",
-       "<polygon fill=\"#696969\" stroke=\"#696969\" points=\"1220.8662,-198.9142 1225.3214,-196.0482 1220.0513,-195.5104 1220.8662,-198.9142\"/>\n",
-       "</g>\n",
-       "<!-- collection_obXokdzOnSH2tytJ0000 -->\n",
-       "<g id=\"node10\" class=\"node\">\n",
-       "<title>collection_obXokdzOnSH2tytJ0000</title>\n",
-       "<path fill=\"#f0fff0\" stroke=\"#065f46\" d=\"M1589.8379,-196C1589.8379,-196 1437.9414,-196 1437.9414,-196 1431.9414,-196 1425.9414,-190 1425.9414,-184 1425.9414,-184 1425.9414,-170 1425.9414,-170 1425.9414,-164 1431.9414,-158 1437.9414,-158 1437.9414,-158 1589.8379,-158 1589.8379,-158 1595.8379,-158 1601.8379,-164 1601.8379,-170 1601.8379,-170 1601.8379,-184 1601.8379,-184 1601.8379,-190 1595.8379,-196 1589.8379,-196\"/>\n",
-       "<text text-anchor=\"start\" x=\"1433.9155\" y=\"-185\" font-family=\"Helvetica,sans-Serif\" font-size=\"10.00\" fill=\"#000000\">🍱 View Habib17 (h5ad) in Vitessce</text>\n",
-       "<text text-anchor=\"start\" x=\"1449.5415\" y=\"-175\" font-family=\"Monospace\" font-size=\"10.00\" fill=\"#c0c0c0\">uid=obXokdzOnSH2tytJ0000</text>\n",
-       "<text text-anchor=\"start\" x=\"1482.8984\" y=\"-165\" font-family=\"Monospace\" font-size=\"10.00\" fill=\"#c0c0c0\">version=None</text>\n",
-       "</g>\n",
-       "<!-- run_wW6GOHDq44lbrdKi08cr&#45;&gt;collection_obXokdzOnSH2tytJ0000 -->\n",
-       "<g id=\"edge10\" class=\"edge\">\n",
-       "<title>run_wW6GOHDq44lbrdKi08cr&#45;&gt;collection_obXokdzOnSH2tytJ0000</title>\n",
-       "<path fill=\"none\" stroke=\"#696969\" d=\"M1051.3531,-246.9988C1139.6368,-236.2868 1289.113,-217.1682 1416.8896,-196 1418.1858,-195.7853 1419.4912,-195.5664 1420.8041,-195.3438\"/>\n",
-       "<polygon fill=\"#696969\" stroke=\"#696969\" points=\"1421.2706,-197.0394 1425.9019,-194.4678 1420.6777,-193.5899 1421.2706,-197.0394\"/>\n",
-       "</g>\n",
-       "<!-- collection_HqfzZmkfYOy20ZNN0000 -->\n",
-       "<g id=\"node11\" class=\"node\">\n",
-       "<title>collection_HqfzZmkfYOy20ZNN0000</title>\n",
-       "<path fill=\"#f0fff0\" stroke=\"#065f46\" d=\"M1884.2336,-196C1884.2336,-196 1631.5457,-196 1631.5457,-196 1625.5457,-196 1619.5457,-190 1619.5457,-184 1619.5457,-184 1619.5457,-170 1619.5457,-170 1619.5457,-164 1625.5457,-158 1631.5457,-158 1631.5457,-158 1884.2336,-158 1884.2336,-158 1890.2336,-158 1896.2336,-164 1896.2336,-170 1896.2336,-170 1896.2336,-184 1896.2336,-184 1896.2336,-190 1890.2336,-196 1884.2336,-196\"/>\n",
-       "<text text-anchor=\"start\" x=\"1627.7178\" y=\"-185\" font-family=\"Helvetica,sans-Serif\" font-size=\"10.00\" fill=\"#000000\">🍱 View PAS OME&#45;TIFF, Neumann et al., 2020 in Vitessce</text>\n",
-       "<text text-anchor=\"start\" x=\"1690.2236\" y=\"-175\" font-family=\"Monospace\" font-size=\"10.00\" fill=\"#c0c0c0\">uid=HqfzZmkfYOy20ZNN0000</text>\n",
-       "<text text-anchor=\"start\" x=\"1726.8984\" y=\"-165\" font-family=\"Monospace\" font-size=\"10.00\" fill=\"#c0c0c0\">version=None</text>\n",
-       "</g>\n",
-       "<!-- run_wW6GOHDq44lbrdKi08cr&#45;&gt;collection_HqfzZmkfYOy20ZNN0000 -->\n",
-       "<g id=\"edge11\" class=\"edge\">\n",
-       "<title>run_wW6GOHDq44lbrdKi08cr&#45;&gt;collection_HqfzZmkfYOy20ZNN0000</title>\n",
-       "<path fill=\"none\" stroke=\"#696969\" d=\"M1051.3387,-249.6451C1170.8584,-239.5166 1409.1858,-218.5428 1610.8896,-196 1612.0325,-195.8723 1613.1802,-195.7432 1614.3323,-195.6129\"/>\n",
-       "<polygon fill=\"#696969\" stroke=\"#696969\" points=\"1614.6407,-197.3392 1619.4103,-195.0339 1614.2442,-193.8617 1614.6407,-197.3392\"/>\n",
-       "</g>\n",
-       "</g>\n",
-       "</svg>\n"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    }
-   ],
+   "outputs": [],
    "source": [
     "ome_tiff_vc_artifact.view_lineage()"
    ]
@@ -1997,7 +1282,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 32,
+   "execution_count": null,
    "metadata": {
     "editable": true,
     "slideshow": {
@@ -2038,7 +1323,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 33,
+   "execution_count": null,
    "metadata": {
     "editable": true,
     "slideshow": {
@@ -2046,25 +1331,7 @@
     },
     "tags": []
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "\u001b[92m→\u001b[0m returning existing artifact with same hash: Artifact(uid='toCvpsqAiH3XcAvT0000', is_latest=True, key='vitessce_examples/visium.ome.zarr', description='Visium OME-Zarr Example', suffix='', type='dataset', size=1400251840, hash='UtsNOkk05EFL34hgUabEwg', n_objects=8809, _hash_type='md5-d', visibility=1, _key_is_virtual=True, storage_id=1, transform_id=17, run_id=79, created_by_id=2, created_at=2024-12-04 14:38:29 UTC)\n"
-     ]
-    },
-    {
-     "data": {
-      "text/plain": [
-       "Artifact(uid='toCvpsqAiH3XcAvT0000', is_latest=True, key='vitessce_examples/visium.ome.zarr', description='Visium OME-Zarr Example', suffix='', type='dataset', size=1400251840, hash='UtsNOkk05EFL34hgUabEwg', n_objects=8809, _hash_type='md5-d', visibility=1, _key_is_virtual=True, storage_id=1, transform_id=18, run_id=85, created_by_id=2, created_at=2024-12-04 14:38:29 UTC)"
-      ]
-     },
-     "execution_count": 33,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "ome_zarr_artifact = ln.Artifact(\n",
     "    ome_zarr_filepath,\n",
@@ -2104,7 +1371,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 34,
+   "execution_count": null,
    "metadata": {
     "editable": true,
     "slideshow": {
@@ -2149,7 +1416,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 35,
+   "execution_count": null,
    "metadata": {
     "editable": true,
     "slideshow": {
@@ -2159,19 +1426,7 @@
      "hide-output"
     ]
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "\u001b[92m→\u001b[0m VitessceConfig references these artifacts:\n",
-      "Artifact(uid='toCvpsqAiH3XcAvT0000', is_latest=True, key='vitessce_examples/visium.ome.zarr', description='Visium OME-Zarr Example', suffix='', type='dataset', size=1400251840, hash='UtsNOkk05EFL34hgUabEwg', n_objects=8809, _hash_type='md5-d', visibility=1, _key_is_virtual=True, storage_id=1, transform_id=18, run_id=85, created_by_id=2, created_at=2024-12-04 14:38:29 UTC)\n",
-      "\u001b[92m→\u001b[0m returning existing artifact with same hash: Artifact(uid='cjvX6EFrdSwsxOQl0000', is_latest=True, description='View Visium OME-Zarr Example in Vitessce', suffix='.vitessce.json', size=1240, hash='PiQa8hZ7nphs4FoTdhOwxg', _hash_type='md5', visibility=1, _key_is_virtual=True, storage_id=1, transform_id=15, run_id=84, created_by_id=2, created_at=2024-12-04 15:53:20 UTC)\n",
-      "\u001b[92m→\u001b[0m VitessceConfig: https://lamin.ai/vitessce/examples/artifact/cjvX6EFrdSwsxOQl0000\n",
-      "\u001b[92m→\u001b[0m Dataset: https://lamin.ai/vitessce/examples/artifact/toCvpsqAiH3XcAvT0000\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "ome_zarr_vc_artifact = ln.integrations.save_vitessce_config(\n",
     "    vc, description=\"View Visium OME-Zarr Example in Vitessce\",\n",
@@ -2180,7 +1435,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 36,
+   "execution_count": null,
    "metadata": {
     "editable": true,
     "slideshow": {
@@ -2188,193 +1443,7 @@
     },
     "tags": []
    },
-   "outputs": [
-    {
-     "data": {
-      "image/svg+xml": [
-       "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"no\"?>\n",
-       "<!DOCTYPE svg PUBLIC \"-//W3C//DTD SVG 1.1//EN\"\n",
-       " \"http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd\">\n",
-       "<!-- Generated by graphviz version 2.40.1 (20161225.0304)\n",
-       " -->\n",
-       "<!-- Title: artifact_cjvX6EFrdSwsxOQl0000 Pages: 1 -->\n",
-       "<svg width=\"2110pt\" height=\"288pt\"\n",
-       " viewBox=\"0.00 0.00 2110.04 288.00\" xmlns=\"http://www.w3.org/2000/svg\" xmlns:xlink=\"http://www.w3.org/1999/xlink\">\n",
-       "<g id=\"graph0\" class=\"graph\" transform=\"scale(1 1) rotate(0) translate(4 284)\">\n",
-       "<title>artifact_cjvX6EFrdSwsxOQl0000</title>\n",
-       "<polygon fill=\"#ffffff\" stroke=\"transparent\" points=\"-4,4 -4,-284 2106.0435,-284 2106.0435,4 -4,4\"/>\n",
-       "<!-- artifact_toCvpsqAiH3XcAvT0000 -->\n",
-       "<g id=\"node1\" class=\"node\">\n",
-       "<title>artifact_toCvpsqAiH3XcAvT0000</title>\n",
-       "<path fill=\"#f0fff0\" stroke=\"#065f46\" d=\"M175.8812,-196C175.8812,-196 49.862,-196 49.862,-196 43.862,-196 37.862,-190 37.862,-184 37.862,-184 37.862,-170 37.862,-170 37.862,-164 43.862,-158 49.862,-158 49.862,-158 175.8812,-158 175.8812,-158 181.8812,-158 187.8812,-164 187.8812,-170 187.8812,-170 187.8812,-184 187.8812,-184 187.8812,-190 181.8812,-196 175.8812,-196\"/>\n",
-       "<text text-anchor=\"start\" x=\"45.6172\" y=\"-185\" font-family=\"Helvetica,sans-Serif\" font-size=\"10.00\" fill=\"#000000\">📄 Visium OME&#45;Zarr Example</text>\n",
-       "<text text-anchor=\"start\" x=\"48.3403\" y=\"-175\" font-family=\"Monospace\" font-size=\"10.00\" fill=\"#c0c0c0\">uid=toCvpsqAiH3XcAvT0000</text>\n",
-       "<text text-anchor=\"start\" x=\"98.2817\" y=\"-165\" font-family=\"Monospace\" font-size=\"10.00\" fill=\"#c0c0c0\">suffix=</text>\n",
-       "</g>\n",
-       "<!-- run_aMMKqF2TfoQCrTnnJhBJ -->\n",
-       "<g id=\"node2\" class=\"node\">\n",
-       "<title>run_aMMKqF2TfoQCrTnnJhBJ</title>\n",
-       "<path fill=\"#dcdcdc\" stroke=\"#065f46\" d=\"M176.614,-122C176.614,-122 49.1292,-122 49.1292,-122 43.1292,-122 37.1292,-116 37.1292,-110 37.1292,-110 37.1292,-86 37.1292,-86 37.1292,-80 43.1292,-74 49.1292,-74 49.1292,-74 176.614,-74 176.614,-74 182.614,-74 188.614,-80 188.614,-86 188.614,-86 188.614,-110 188.614,-110 188.614,-116 182.614,-122 176.614,-122\"/>\n",
-       "<text text-anchor=\"start\" x=\"57.4556\" y=\"-111\" font-family=\"Helvetica,sans-Serif\" font-size=\"10.00\" fill=\"#000000\">🔧 save_vitessce_config</text>\n",
-       "<text text-anchor=\"start\" x=\"58.897\" y=\"-101\" font-family=\"Monospace\" font-size=\"10.00\" fill=\"#c0c0c0\">uid=kup03MJBsIVa0002</text>\n",
-       "<text text-anchor=\"start\" x=\"48.6699\" y=\"-91\" font-family=\"Monospace\" font-size=\"10.00\" fill=\"#c0c0c0\">type=function, user=mkeller7</text>\n",
-       "<text text-anchor=\"start\" x=\"45.0005\" y=\"-81\" font-family=\"Monospace\" font-size=\"10.00\" fill=\"#c0c0c0\">run=2024&#45;12&#45;04 16:11:51 UTC</text>\n",
-       "</g>\n",
-       "<!-- artifact_toCvpsqAiH3XcAvT0000&#45;&gt;run_aMMKqF2TfoQCrTnnJhBJ -->\n",
-       "<g id=\"edge1\" class=\"edge\">\n",
-       "<title>artifact_toCvpsqAiH3XcAvT0000&#45;&gt;run_aMMKqF2TfoQCrTnnJhBJ</title>\n",
-       "<path fill=\"none\" stroke=\"#696969\" d=\"M112.8716,-157.8763C112.8716,-148.6991 112.8716,-137.5013 112.8716,-127.2829\"/>\n",
-       "<polygon fill=\"#696969\" stroke=\"#696969\" points=\"114.6217,-127.0445 112.8716,-122.0445 111.1217,-127.0445 114.6217,-127.0445\"/>\n",
-       "</g>\n",
-       "<!-- artifact_cjvX6EFrdSwsxOQl0000 -->\n",
-       "<g id=\"node3\" class=\"node\">\n",
-       "<title>artifact_cjvX6EFrdSwsxOQl0000</title>\n",
-       "<path fill=\"#10b981\" stroke=\"#065f46\" d=\"M213.6149,-38C213.6149,-38 12.1283,-38 12.1283,-38 6.1283,-38 .1283,-32 .1283,-26 .1283,-26 .1283,-12 .1283,-12 .1283,-6 6.1283,0 12.1283,0 12.1283,0 213.6149,0 213.6149,0 219.6149,0 225.6149,-6 225.6149,-12 225.6149,-12 225.6149,-26 225.6149,-26 225.6149,-32 219.6149,-38 213.6149,-38\"/>\n",
-       "<text text-anchor=\"start\" x=\"8\" y=\"-27\" font-family=\"Helvetica,sans-Serif\" font-size=\"10.00\" fill=\"#000000\">📄 View Visium OME&#45;Zarr Example in Vitessce</text>\n",
-       "<text text-anchor=\"start\" x=\"48.2598\" y=\"-17\" font-family=\"Monospace\" font-size=\"10.00\" fill=\"#c0c0c0\">uid=cjvX6EFrdSwsxOQl0000</text>\n",
-       "<text text-anchor=\"start\" x=\"68.2695\" y=\"-7\" font-family=\"Monospace\" font-size=\"10.00\" fill=\"#c0c0c0\">suffix=.vitessce.json</text>\n",
-       "</g>\n",
-       "<!-- run_aMMKqF2TfoQCrTnnJhBJ&#45;&gt;artifact_cjvX6EFrdSwsxOQl0000 -->\n",
-       "<g id=\"edge2\" class=\"edge\">\n",
-       "<title>run_aMMKqF2TfoQCrTnnJhBJ&#45;&gt;artifact_cjvX6EFrdSwsxOQl0000</title>\n",
-       "<path fill=\"none\" stroke=\"#696969\" d=\"M112.8716,-73.8681C112.8716,-64.2201 112.8716,-53.1228 112.8716,-43.4439\"/>\n",
-       "<polygon fill=\"#696969\" stroke=\"#696969\" points=\"114.6217,-43.2308 112.8716,-38.2309 111.1217,-43.2309 114.6217,-43.2308\"/>\n",
-       "</g>\n",
-       "<!-- run_wW6GOHDq44lbrdKi08cr -->\n",
-       "<g id=\"node4\" class=\"node\">\n",
-       "<title>run_wW6GOHDq44lbrdKi08cr</title>\n",
-       "<path fill=\"#dcdcdc\" stroke=\"#065f46\" d=\"M1127.3518,-280C1127.3518,-280 998.3913,-280 998.3913,-280 992.3913,-280 986.3913,-274 986.3913,-268 986.3913,-268 986.3913,-244 986.3913,-244 986.3913,-238 992.3913,-232 998.3913,-232 998.3913,-232 1127.3518,-232 1127.3518,-232 1133.3518,-232 1139.3518,-238 1139.3518,-244 1139.3518,-244 1139.3518,-268 1139.3518,-268 1139.3518,-274 1133.3518,-280 1127.3518,-280\"/>\n",
-       "<text text-anchor=\"start\" x=\"1036.1738\" y=\"-269\" font-family=\"Helvetica,sans-Serif\" font-size=\"10.00\" fill=\"#000000\">📔 Vitessce</text>\n",
-       "<text text-anchor=\"start\" x=\"1006.5923\" y=\"-259\" font-family=\"Monospace\" font-size=\"10.00\" fill=\"#c0c0c0\">uid=BZhZQ6uIbkWv0000</text>\n",
-       "<text text-anchor=\"start\" x=\"995.6084\" y=\"-249\" font-family=\"Monospace\" font-size=\"10.00\" fill=\"#c0c0c0\">type=notebook, user=mkeller7</text>\n",
-       "<text text-anchor=\"start\" x=\"994.6318\" y=\"-239\" font-family=\"Monospace\" font-size=\"10.00\" fill=\"#c0c0c0\">run=2024&#45;12&#45;04 16:10:55 UTC</text>\n",
-       "</g>\n",
-       "<!-- run_wW6GOHDq44lbrdKi08cr&#45;&gt;artifact_toCvpsqAiH3XcAvT0000 -->\n",
-       "<g id=\"edge8\" class=\"edge\">\n",
-       "<title>run_wW6GOHDq44lbrdKi08cr&#45;&gt;artifact_toCvpsqAiH3XcAvT0000</title>\n",
-       "<path fill=\"none\" stroke=\"#696969\" d=\"M986.577,-254.6356C835.2106,-251.0654 486.5147,-238.5348 196.8716,-196 195.7297,-195.8323 194.5804,-195.6575 193.425,-195.4761\"/>\n",
-       "<polygon fill=\"#696969\" stroke=\"#696969\" points=\"193.5425,-193.722 188.3253,-194.6403 192.9764,-197.176 193.5425,-193.722\"/>\n",
-       "</g>\n",
-       "<!-- artifact_1g3a41z0hggWNBrk0000 -->\n",
-       "<g id=\"node5\" class=\"node\">\n",
-       "<title>artifact_1g3a41z0hggWNBrk0000</title>\n",
-       "<path fill=\"#f0fff0\" stroke=\"#065f46\" d=\"M405.7671,-196C405.7671,-196 217.976,-196 217.976,-196 211.976,-196 205.976,-190 205.976,-184 205.976,-184 205.976,-170 205.976,-170 205.976,-164 211.976,-158 217.976,-158 217.976,-158 405.7671,-158 405.7671,-158 411.7671,-158 417.7671,-164 417.7671,-170 417.7671,-170 417.7671,-184 417.7671,-184 417.7671,-190 411.7671,-196 405.7671,-196\"/>\n",
-       "<text text-anchor=\"start\" x=\"213.9238\" y=\"-185\" font-family=\"Helvetica,sans-Serif\" font-size=\"10.00\" fill=\"#000000\">📄 Habib et al., 2017 Nature Methods, h5ad</text>\n",
-       "<text text-anchor=\"start\" x=\"245.0186\" y=\"-175\" font-family=\"Monospace\" font-size=\"10.00\" fill=\"#c0c0c0\">uid=1g3a41z0hggWNBrk0000</text>\n",
-       "<text text-anchor=\"start\" x=\"284.7695\" y=\"-165\" font-family=\"Monospace\" font-size=\"10.00\" fill=\"#c0c0c0\">suffix=.h5ad</text>\n",
-       "</g>\n",
-       "<!-- run_wW6GOHDq44lbrdKi08cr&#45;&gt;artifact_1g3a41z0hggWNBrk0000 -->\n",
-       "<g id=\"edge3\" class=\"edge\">\n",
-       "<title>run_wW6GOHDq44lbrdKi08cr&#45;&gt;artifact_1g3a41z0hggWNBrk0000</title>\n",
-       "<path fill=\"none\" stroke=\"#696969\" d=\"M986.3181,-250.5102C866.6588,-241.539 628.1475,-222.0891 426.8716,-196 425.5985,-195.835 424.3179,-195.6665 423.031,-195.4948\"/>\n",
-       "<polygon fill=\"#696969\" stroke=\"#696969\" points=\"423.2278,-193.7555 418.0378,-194.8171 422.757,-197.2237 423.2278,-193.7555\"/>\n",
-       "</g>\n",
-       "<!-- artifact_O7CTVi6XjnfsceQ20000 -->\n",
-       "<g id=\"node6\" class=\"node\">\n",
-       "<title>artifact_O7CTVi6XjnfsceQ20000</title>\n",
-       "<path fill=\"#f0fff0\" stroke=\"#065f46\" d=\"M748.07,-196C748.07,-196 447.6732,-196 447.6732,-196 441.6732,-196 435.6732,-190 435.6732,-184 435.6732,-184 435.6732,-170 435.6732,-170 435.6732,-164 441.6732,-158 447.6732,-158 447.6732,-158 748.07,-158 748.07,-158 754.07,-158 760.07,-164 760.07,-170 760.07,-170 760.07,-184 760.07,-184 760.07,-190 754.07,-196 748.07,-196\"/>\n",
-       "<text text-anchor=\"start\" x=\"443.5225\" y=\"-185\" font-family=\"Helvetica,sans-Serif\" font-size=\"10.00\" fill=\"#000000\">📄 Reference JSON for H5AD file, Habib et al., 2017 Nature Methods</text>\n",
-       "<text text-anchor=\"start\" x=\"533.6162\" y=\"-175\" font-family=\"Monospace\" font-size=\"10.00\" fill=\"#c0c0c0\">uid=O7CTVi6XjnfsceQ20000</text>\n",
-       "<text text-anchor=\"start\" x=\"572.7202\" y=\"-165\" font-family=\"Monospace\" font-size=\"10.00\" fill=\"#c0c0c0\">suffix=.json</text>\n",
-       "</g>\n",
-       "<!-- run_wW6GOHDq44lbrdKi08cr&#45;&gt;artifact_O7CTVi6XjnfsceQ20000 -->\n",
-       "<g id=\"edge4\" class=\"edge\">\n",
-       "<title>run_wW6GOHDq44lbrdKi08cr&#45;&gt;artifact_O7CTVi6XjnfsceQ20000</title>\n",
-       "<path fill=\"none\" stroke=\"#696969\" d=\"M986.607,-243.0432C912.8412,-230.511 800.0233,-211.3441 714.8918,-196.8809\"/>\n",
-       "<polygon fill=\"#696969\" stroke=\"#696969\" points=\"715.0603,-195.1345 709.8378,-196.0222 714.474,-198.585 715.0603,-195.1345\"/>\n",
-       "</g>\n",
-       "<!-- artifact_nelDyBfwvEIIAKcC0000 -->\n",
-       "<g id=\"node7\" class=\"node\">\n",
-       "<title>artifact_nelDyBfwvEIIAKcC0000</title>\n",
-       "<path fill=\"#f0fff0\" stroke=\"#065f46\" d=\"M923.6413,-196C923.6413,-196 790.1019,-196 790.1019,-196 784.1019,-196 778.1019,-190 778.1019,-184 778.1019,-184 778.1019,-170 778.1019,-170 778.1019,-164 784.1019,-158 790.1019,-158 790.1019,-158 923.6413,-158 923.6413,-158 929.6413,-158 935.6413,-164 935.6413,-170 935.6413,-170 935.6413,-184 935.6413,-184 935.6413,-190 929.6413,-196 923.6413,-196\"/>\n",
-       "<text text-anchor=\"start\" x=\"785.9868\" y=\"-185\" font-family=\"Helvetica,sans-Serif\" font-size=\"10.00\" fill=\"#000000\">📄 Visium SpatialData Example</text>\n",
-       "<text text-anchor=\"start\" x=\"793.644\" y=\"-175\" font-family=\"Monospace\" font-size=\"10.00\" fill=\"#c0c0c0\">uid=nelDyBfwvEIIAKcC0000</text>\n",
-       "<text text-anchor=\"start\" x=\"832.2817\" y=\"-165\" font-family=\"Monospace\" font-size=\"10.00\" fill=\"#c0c0c0\">suffix=.zarr</text>\n",
-       "</g>\n",
-       "<!-- run_wW6GOHDq44lbrdKi08cr&#45;&gt;artifact_nelDyBfwvEIIAKcC0000 -->\n",
-       "<g id=\"edge5\" class=\"edge\">\n",
-       "<title>run_wW6GOHDq44lbrdKi08cr&#45;&gt;artifact_nelDyBfwvEIIAKcC0000</title>\n",
-       "<path fill=\"none\" stroke=\"#696969\" d=\"M1000.2258,-231.9756C971.8036,-221.0759 938.5119,-208.3087 911.1688,-197.8227\"/>\n",
-       "<polygon fill=\"#696969\" stroke=\"#696969\" points=\"911.7802,-196.183 906.4851,-196.0265 910.5269,-199.4509 911.7802,-196.183\"/>\n",
-       "</g>\n",
-       "<!-- artifact_0I5aMNdh2UrECtFX0000 -->\n",
-       "<g id=\"node8\" class=\"node\">\n",
-       "<title>artifact_0I5aMNdh2UrECtFX0000</title>\n",
-       "<path fill=\"#f0fff0\" stroke=\"#065f46\" d=\"M1159.651,-196C1159.651,-196 966.0922,-196 966.0922,-196 960.0922,-196 954.0922,-190 954.0922,-184 954.0922,-184 954.0922,-170 954.0922,-170 954.0922,-164 960.0922,-158 966.0922,-158 966.0922,-158 1159.651,-158 1159.651,-158 1165.651,-158 1171.651,-164 1171.651,-170 1171.651,-170 1171.651,-184 1171.651,-184 1171.651,-190 1165.651,-196 1159.651,-196\"/>\n",
-       "<text text-anchor=\"start\" x=\"961.9819\" y=\"-185\" font-family=\"Helvetica,sans-Serif\" font-size=\"10.00\" fill=\"#000000\">📄 PAS OME&#45;TIFF file, Neumann et al., 2020</text>\n",
-       "<text text-anchor=\"start\" x=\"996.3066\" y=\"-175\" font-family=\"Monospace\" font-size=\"10.00\" fill=\"#c0c0c0\">uid=0I5aMNdh2UrECtFX0000</text>\n",
-       "<text text-anchor=\"start\" x=\"1043.0034\" y=\"-165\" font-family=\"Monospace\" font-size=\"10.00\" fill=\"#c0c0c0\">suffix=.tif</text>\n",
-       "</g>\n",
-       "<!-- run_wW6GOHDq44lbrdKi08cr&#45;&gt;artifact_0I5aMNdh2UrECtFX0000 -->\n",
-       "<g id=\"edge6\" class=\"edge\">\n",
-       "<title>run_wW6GOHDq44lbrdKi08cr&#45;&gt;artifact_0I5aMNdh2UrECtFX0000</title>\n",
-       "<path fill=\"none\" stroke=\"#696969\" d=\"M1062.8716,-231.8681C1062.8716,-222.2201 1062.8716,-211.1228 1062.8716,-201.4439\"/>\n",
-       "<polygon fill=\"#696969\" stroke=\"#696969\" points=\"1064.6217,-201.2308 1062.8716,-196.2309 1061.1217,-201.2309 1064.6217,-201.2308\"/>\n",
-       "</g>\n",
-       "<!-- artifact_CMBUzbNNCEDGCKcQ0000 -->\n",
-       "<g id=\"node9\" class=\"node\">\n",
-       "<title>artifact_CMBUzbNNCEDGCKcQ0000</title>\n",
-       "<path fill=\"#f0fff0\" stroke=\"#065f46\" d=\"M1377.7212,-196C1377.7212,-196 1202.0219,-196 1202.0219,-196 1196.0219,-196 1190.0219,-190 1190.0219,-184 1190.0219,-184 1190.0219,-170 1190.0219,-170 1190.0219,-164 1196.0219,-158 1202.0219,-158 1202.0219,-158 1377.7212,-158 1377.7212,-158 1383.7212,-158 1389.7212,-164 1389.7212,-170 1389.7212,-170 1389.7212,-184 1389.7212,-184 1389.7212,-190 1383.7212,-196 1377.7212,-196\"/>\n",
-       "<text text-anchor=\"start\" x=\"1197.9468\" y=\"-185\" font-family=\"Helvetica,sans-Serif\" font-size=\"10.00\" fill=\"#000000\">📄 PAS offsets file, Neumann et al., 2020</text>\n",
-       "<text text-anchor=\"start\" x=\"1214.1514\" y=\"-175\" font-family=\"Monospace\" font-size=\"10.00\" fill=\"#c0c0c0\">uid=CMBUzbNNCEDGCKcQ0000</text>\n",
-       "<text text-anchor=\"start\" x=\"1264.7202\" y=\"-165\" font-family=\"Monospace\" font-size=\"10.00\" fill=\"#c0c0c0\">suffix=.json</text>\n",
-       "</g>\n",
-       "<!-- run_wW6GOHDq44lbrdKi08cr&#45;&gt;artifact_CMBUzbNNCEDGCKcQ0000 -->\n",
-       "<g id=\"edge7\" class=\"edge\">\n",
-       "<title>run_wW6GOHDq44lbrdKi08cr&#45;&gt;artifact_CMBUzbNNCEDGCKcQ0000</title>\n",
-       "<path fill=\"none\" stroke=\"#696969\" d=\"M1131.9036,-231.9756C1163.3526,-221.0308 1200.212,-208.2031 1230.4124,-197.6928\"/>\n",
-       "<polygon fill=\"#696969\" stroke=\"#696969\" points=\"1231.0534,-199.3228 1235.2004,-196.0265 1229.903,-196.0172 1231.0534,-199.3228\"/>\n",
-       "</g>\n",
-       "<!-- artifact_kWwG45Hr26KZUW3g0004 -->\n",
-       "<g id=\"node10\" class=\"node\">\n",
-       "<title>artifact_kWwG45Hr26KZUW3g0004</title>\n",
-       "<path fill=\"#f0fff0\" stroke=\"#065f46\" d=\"M1602.2427,-196C1602.2427,-196 1419.5004,-196 1419.5004,-196 1413.5004,-196 1407.5004,-190 1407.5004,-184 1407.5004,-184 1407.5004,-170 1407.5004,-170 1407.5004,-164 1413.5004,-158 1419.5004,-158 1419.5004,-158 1602.2427,-158 1602.2427,-158 1608.2427,-158 1614.2427,-164 1614.2427,-170 1614.2427,-170 1614.2427,-184 1614.2427,-184 1614.2427,-190 1608.2427,-196 1602.2427,-196\"/>\n",
-       "<text text-anchor=\"start\" x=\"1415.436\" y=\"-185\" font-family=\"Helvetica,sans-Serif\" font-size=\"10.00\" fill=\"#000000\">📄 Habib et al., 2017 Nature Methods, zarr</text>\n",
-       "<text text-anchor=\"start\" x=\"1438.7573\" y=\"-175\" font-family=\"Monospace\" font-size=\"10.00\" fill=\"#c0c0c0\">uid=kWwG45Hr26KZUW3g0004</text>\n",
-       "<text text-anchor=\"start\" x=\"1466.8188\" y=\"-165\" font-family=\"Monospace\" font-size=\"10.00\" fill=\"#c0c0c0\">suffix=.anndata.zarr</text>\n",
-       "</g>\n",
-       "<!-- run_wW6GOHDq44lbrdKi08cr&#45;&gt;artifact_kWwG45Hr26KZUW3g0004 -->\n",
-       "<g id=\"edge9\" class=\"edge\">\n",
-       "<title>run_wW6GOHDq44lbrdKi08cr&#45;&gt;artifact_kWwG45Hr26KZUW3g0004</title>\n",
-       "<path fill=\"none\" stroke=\"#696969\" d=\"M1139.1224,-242.554C1211.3456,-229.8182 1320.559,-210.5596 1401.9473,-196.2076\"/>\n",
-       "<polygon fill=\"#696969\" stroke=\"#696969\" points=\"1402.6472,-197.8613 1407.2673,-195.2695 1402.0393,-194.4145 1402.6472,-197.8613\"/>\n",
-       "</g>\n",
-       "<!-- collection_obXokdzOnSH2tytJ0000 -->\n",
-       "<g id=\"node11\" class=\"node\">\n",
-       "<title>collection_obXokdzOnSH2tytJ0000</title>\n",
-       "<path fill=\"#f0fff0\" stroke=\"#065f46\" d=\"M1795.8198,-196C1795.8198,-196 1643.9233,-196 1643.9233,-196 1637.9233,-196 1631.9233,-190 1631.9233,-184 1631.9233,-184 1631.9233,-170 1631.9233,-170 1631.9233,-164 1637.9233,-158 1643.9233,-158 1643.9233,-158 1795.8198,-158 1795.8198,-158 1801.8198,-158 1807.8198,-164 1807.8198,-170 1807.8198,-170 1807.8198,-184 1807.8198,-184 1807.8198,-190 1801.8198,-196 1795.8198,-196\"/>\n",
-       "<text text-anchor=\"start\" x=\"1639.8975\" y=\"-185\" font-family=\"Helvetica,sans-Serif\" font-size=\"10.00\" fill=\"#000000\">🍱 View Habib17 (h5ad) in Vitessce</text>\n",
-       "<text text-anchor=\"start\" x=\"1655.5234\" y=\"-175\" font-family=\"Monospace\" font-size=\"10.00\" fill=\"#c0c0c0\">uid=obXokdzOnSH2tytJ0000</text>\n",
-       "<text text-anchor=\"start\" x=\"1688.8804\" y=\"-165\" font-family=\"Monospace\" font-size=\"10.00\" fill=\"#c0c0c0\">version=None</text>\n",
-       "</g>\n",
-       "<!-- run_wW6GOHDq44lbrdKi08cr&#45;&gt;collection_obXokdzOnSH2tytJ0000 -->\n",
-       "<g id=\"edge10\" class=\"edge\">\n",
-       "<title>run_wW6GOHDq44lbrdKi08cr&#45;&gt;collection_obXokdzOnSH2tytJ0000</title>\n",
-       "<path fill=\"none\" stroke=\"#696969\" d=\"M1139.2262,-249.9316C1247.2672,-240.8654 1450.782,-222.0231 1622.8716,-196 1624.1706,-195.8036 1625.4788,-195.6019 1626.7943,-195.3954\"/>\n",
-       "<polygon fill=\"#696969\" stroke=\"#696969\" points=\"1627.2412,-197.0962 1631.9011,-194.5766 1626.6871,-193.6403 1627.2412,-197.0962\"/>\n",
-       "</g>\n",
-       "<!-- collection_HqfzZmkfYOy20ZNN0000 -->\n",
-       "<g id=\"node12\" class=\"node\">\n",
-       "<title>collection_HqfzZmkfYOy20ZNN0000</title>\n",
-       "<path fill=\"#f0fff0\" stroke=\"#065f46\" d=\"M2090.2155,-196C2090.2155,-196 1837.5276,-196 1837.5276,-196 1831.5276,-196 1825.5276,-190 1825.5276,-184 1825.5276,-184 1825.5276,-170 1825.5276,-170 1825.5276,-164 1831.5276,-158 1837.5276,-158 1837.5276,-158 2090.2155,-158 2090.2155,-158 2096.2155,-158 2102.2155,-164 2102.2155,-170 2102.2155,-170 2102.2155,-184 2102.2155,-184 2102.2155,-190 2096.2155,-196 2090.2155,-196\"/>\n",
-       "<text text-anchor=\"start\" x=\"1833.6997\" y=\"-185\" font-family=\"Helvetica,sans-Serif\" font-size=\"10.00\" fill=\"#000000\">🍱 View PAS OME&#45;TIFF, Neumann et al., 2020 in Vitessce</text>\n",
-       "<text text-anchor=\"start\" x=\"1896.2056\" y=\"-175\" font-family=\"Monospace\" font-size=\"10.00\" fill=\"#c0c0c0\">uid=HqfzZmkfYOy20ZNN0000</text>\n",
-       "<text text-anchor=\"start\" x=\"1932.8804\" y=\"-165\" font-family=\"Monospace\" font-size=\"10.00\" fill=\"#c0c0c0\">version=None</text>\n",
-       "</g>\n",
-       "<!-- run_wW6GOHDq44lbrdKi08cr&#45;&gt;collection_HqfzZmkfYOy20ZNN0000 -->\n",
-       "<g id=\"edge11\" class=\"edge\">\n",
-       "<title>run_wW6GOHDq44lbrdKi08cr&#45;&gt;collection_HqfzZmkfYOy20ZNN0000</title>\n",
-       "<path fill=\"none\" stroke=\"#696969\" d=\"M1139.2411,-251.168C1275.5232,-242.2676 1569.5338,-221.8097 1816.8716,-196 1818.0153,-195.8807 1819.1639,-195.7597 1820.3169,-195.6372\"/>\n",
-       "<polygon fill=\"#696969\" stroke=\"#696969\" points=\"1820.6142,-197.3654 1825.3983,-195.0905 1820.2398,-193.8855 1820.6142,-197.3654\"/>\n",
-       "</g>\n",
-       "</g>\n",
-       "</svg>\n"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    }
-   ],
+   "outputs": [],
    "source": [
     "ome_zarr_vc_artifact.view_lineage()"
    ]
@@ -2398,7 +1467,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 38,
+   "execution_count": null,
    "metadata": {
     "editable": true,
     "slideshow": {
@@ -2406,31 +1475,7 @@
     },
     "tags": []
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "\u001b[93m!\u001b[0m cells [(0, None), (None, 1)] were not run consecutively\n"
-     ]
-    },
-    {
-     "name": "stdin",
-     "output_type": "stream",
-     "text": [
-      "   Do you still want to proceed with finishing? (y/n)  y\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "\u001b[92m→\u001b[0m finished Run('wW6GOHDq') after 0d 0h 1m 9s at 2024-12-04 16:12:04 UTC\n",
-      "\u001b[92m→\u001b[0m go to: https://lamin.ai/vitessce/examples/transform/BZhZQ6uIbkWv0000\n",
-      "\u001b[92m→\u001b[0m if you want to update your notebook without re-running it, use `lamin save /Users/markkeller/research/dbmi/vitessce/lamin/lamin-spatial/docs/vitessce.ipynb`\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "# [optional] finish run context and auto-save the notebook\n",
     "ln.finish()"

--- a/docs/vitessce.ipynb
+++ b/docs/vitessce.ipynb
@@ -27,23 +27,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": null,
    "metadata": {
+    "editable": true,
+    "slideshow": {
+     "slide_type": ""
+    },
     "tags": [
      "hide-output"
     ]
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "\u001b[93m!\u001b[0m the database (0.76.7) is behind your installed lamindb package (0.77.2)\n",
-      "\u001b[92m→\u001b[0m consider migrating your database: lamin migrate deploy\n",
-      "\u001b[92m→\u001b[0m connected lamindb: vitessce/examples\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "# !pip install \"vitessce[all]>=3.5.0\"\n",
     "# !pip install \"generate-tiff-offsets>=0.1.9\"\n",
@@ -53,8 +47,12 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 1,
    "metadata": {
+    "editable": true,
+    "slideshow": {
+     "slide_type": ""
+    },
     "tags": [
      "hide-output"
     ]
@@ -64,8 +62,9 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[92m→\u001b[0m created Transform('XmcumVqv'), started new Run('xt2ErUgo') at 2024-12-04 16:00:56 UTC\n",
-      "\u001b[92m→\u001b[0m notebook imports: anndata==0.10.8 generate-tiff-offsets==0.1.9 lamindb==0.77.2 numpy==1.26.4 vitessce==3.5.0\n"
+      "\u001b[92m→\u001b[0m connected lamindb: vitessce/examples\n",
+      "\u001b[92m→\u001b[0m created Transform('BZhZQ6uI'), started new Run('wW6GOHDq') at 2024-12-04 16:10:55 UTC\n",
+      "\u001b[92m→\u001b[0m notebook imports: anndata==0.10.8 generate-tiff-offsets==0.1.9 lamindb==0.77.2 vitessce==3.5.0\n"
      ]
     }
    ],
@@ -86,7 +85,13 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "editable": true,
+    "slideshow": {
+     "slide_type": ""
+    },
+    "tags": []
+   },
    "source": [
     "## Visualize an AnnData object (H5AD format)"
    ]
@@ -100,8 +105,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
-   "metadata": {},
+   "execution_count": 2,
+   "metadata": {
+    "editable": true,
+    "slideshow": {
+     "slide_type": ""
+    },
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "h5ad_raw_filepath = \"./habib17.raw.h5ad\"\n",
@@ -114,15 +125,27 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "editable": true,
+    "slideshow": {
+     "slide_type": ""
+    },
+    "tags": []
+   },
    "source": [
     "This AnnData file was not saved recently and `read_h5ad` will warn us about this. By reading and subsequently re-writing the file using an up-to-date `anndata` package version, we ensure that the dataset is saved using the latest AnnData H5AD format."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
-   "metadata": {},
+   "execution_count": 3,
+   "metadata": {
+    "editable": true,
+    "slideshow": {
+     "slide_type": ""
+    },
+    "tags": []
+   },
    "outputs": [
     {
      "name": "stderr",
@@ -145,15 +168,27 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "editable": true,
+    "slideshow": {
+     "slide_type": ""
+    },
+    "tags": []
+   },
    "source": [
     "Optionally, we can modify the AnnData object, for example to subset it to the highly variable genes (which will affect the amount of data that is displayed in the heatmap visualization)."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
-   "metadata": {},
+   "execution_count": 4,
+   "metadata": {
+    "editable": true,
+    "slideshow": {
+     "slide_type": ""
+    },
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "adata = adata[:, adata.var[\"highly_variable\"]].copy()"
@@ -161,8 +196,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
-   "metadata": {},
+   "execution_count": 5,
+   "metadata": {
+    "editable": true,
+    "slideshow": {
+     "slide_type": ""
+    },
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "adata.write_h5ad(h5ad_processed_filepath)"
@@ -170,39 +211,56 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "editable": true,
+    "slideshow": {
+     "slide_type": ""
+    },
+    "tags": []
+   },
    "source": [
     "### Save the dataset"
    ]
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "editable": true,
+    "slideshow": {
+     "slide_type": ""
+    },
+    "tags": []
+   },
    "source": [
     "Save the `.h5ad` file as a LaminDB Artifact."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": 6,
    "metadata": {
-    "scrolled": true
+    "editable": true,
+    "scrolled": true,
+    "slideshow": {
+     "slide_type": ""
+    },
+    "tags": []
    },
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[92m→\u001b[0m returning existing artifact with same hash: Artifact(uid='1g3a41z0hggWNBrk0000', is_latest=True, key='vitessce_examples/habib17.h5ad', description='Habib et al., 2017 Nature Methods, h5ad', suffix='.h5ad', type='dataset', size=22586523, hash='-O1gvNOMqXm96TNFJ4yZXQ', _hash_type='md5', _accessor='AnnData', visibility=1, _key_is_virtual=True, storage_id=1, transform_id=16, run_id=73, created_by_id=2, created_at=2024-12-03 21:31:03 UTC)\n"
+      "\u001b[92m→\u001b[0m returning existing artifact with same hash: Artifact(uid='1g3a41z0hggWNBrk0000', is_latest=True, key='vitessce_examples/habib17.h5ad', description='Habib et al., 2017 Nature Methods, h5ad', suffix='.h5ad', type='dataset', size=22586523, hash='-O1gvNOMqXm96TNFJ4yZXQ', _hash_type='md5', _accessor='AnnData', visibility=1, _key_is_virtual=True, storage_id=1, transform_id=17, run_id=79, created_by_id=2, created_at=2024-12-03 21:31:03 UTC)\n"
      ]
     },
     {
      "data": {
       "text/plain": [
-       "Artifact(uid='1g3a41z0hggWNBrk0000', is_latest=True, key='vitessce_examples/habib17.h5ad', description='Habib et al., 2017 Nature Methods, h5ad', suffix='.h5ad', type='dataset', size=22586523, hash='-O1gvNOMqXm96TNFJ4yZXQ', _hash_type='md5', _accessor='AnnData', visibility=1, _key_is_virtual=True, storage_id=1, transform_id=17, run_id=79, created_by_id=2, created_at=2024-12-03 21:31:03 UTC)"
+       "Artifact(uid='1g3a41z0hggWNBrk0000', is_latest=True, key='vitessce_examples/habib17.h5ad', description='Habib et al., 2017 Nature Methods, h5ad', suffix='.h5ad', type='dataset', size=22586523, hash='-O1gvNOMqXm96TNFJ4yZXQ', _hash_type='md5', _accessor='AnnData', visibility=1, _key_is_virtual=True, storage_id=1, transform_id=18, run_id=85, created_by_id=2, created_at=2024-12-03 21:31:03 UTC)"
       ]
      },
-     "execution_count": 13,
+     "execution_count": 6,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -219,15 +277,27 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "editable": true,
+    "slideshow": {
+     "slide_type": ""
+    },
+    "tags": []
+   },
    "source": [
     "When using `.h5ad` files, we construct a [Reference Specification](https://fsspec.github.io/kerchunk/spec.html) which enables interoperability with the [Zarr](https://zarrita.dev/packages/storage.html#referencestore) interface."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
-   "metadata": {},
+   "execution_count": 7,
+   "metadata": {
+    "editable": true,
+    "slideshow": {
+     "slide_type": ""
+    },
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "ref_spec = vitdu.generate_h5ad_ref_spec(h5ad_processed_filepath)"
@@ -235,21 +305,33 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "editable": true,
+    "slideshow": {
+     "slide_type": ""
+    },
+    "tags": []
+   },
    "source": [
     "We next need to save the corresponding Reference Specification to a JSON file and upload it to LaminDB as an Artifact."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
-   "metadata": {},
+   "execution_count": 8,
+   "metadata": {
+    "editable": true,
+    "slideshow": {
+     "slide_type": ""
+    },
+    "tags": []
+   },
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[92m→\u001b[0m returning existing artifact with same hash: Artifact(uid='O7CTVi6XjnfsceQ20000', is_latest=True, key='vitessce_examples/habib17.reference.json', description='Reference JSON for H5AD file, Habib et al., 2017 Nature Methods', suffix='.json', size=543575, hash='XFOV2X6Bw6_zTugTOEBehg', _hash_type='md5', visibility=1, _key_is_virtual=True, storage_id=1, transform_id=16, run_id=73, created_by_id=2, created_at=2024-12-03 21:31:14 UTC)\n"
+      "\u001b[92m→\u001b[0m returning existing artifact with same hash: Artifact(uid='O7CTVi6XjnfsceQ20000', is_latest=True, key='vitessce_examples/habib17.reference.json', description='Reference JSON for H5AD file, Habib et al., 2017 Nature Methods', suffix='.json', size=543575, hash='XFOV2X6Bw6_zTugTOEBehg', _hash_type='md5', visibility=1, _key_is_virtual=True, storage_id=1, transform_id=17, run_id=79, created_by_id=2, created_at=2024-12-03 21:31:14 UTC)\n"
      ]
     }
    ],
@@ -266,29 +348,53 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "editable": true,
+    "slideshow": {
+     "slide_type": ""
+    },
+    "tags": []
+   },
    "source": [
     "### Save a VitessceConfig object"
    ]
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "editable": true,
+    "slideshow": {
+     "slide_type": ""
+    },
+    "tags": []
+   },
    "source": [
     "You can create a dashboard for one or several datasets by using Vitessce's component API."
    ]
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "editable": true,
+    "slideshow": {
+     "slide_type": ""
+    },
+    "tags": []
+   },
    "source": [
     "You can pass LaminDB Artifacts to the AnnDataWrapper class using the `adata_artifact` and `ref_artifact` [parameters](https://python-docs.vitessce.io/api_data.html#vitessce.wrappers.AnnDataWrapper)."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
-   "metadata": {},
+   "execution_count": 9,
+   "metadata": {
+    "editable": true,
+    "slideshow": {
+     "slide_type": ""
+    },
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "vc = vit.VitessceConfig(\n",
@@ -317,15 +423,25 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "editable": true,
+    "slideshow": {
+     "slide_type": ""
+    },
+    "tags": []
+   },
    "source": [
     "Save the `VitessceConfig` object."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
+   "execution_count": 10,
    "metadata": {
+    "editable": true,
+    "slideshow": {
+     "slide_type": ""
+    },
     "tags": [
      "hide-output"
     ]
@@ -336,10 +452,10 @@
      "output_type": "stream",
      "text": [
       "\u001b[92m→\u001b[0m VitessceConfig references these artifacts:\n",
-      "Artifact(uid='1g3a41z0hggWNBrk0000', is_latest=True, key='vitessce_examples/habib17.h5ad', description='Habib et al., 2017 Nature Methods, h5ad', suffix='.h5ad', type='dataset', size=22586523, hash='-O1gvNOMqXm96TNFJ4yZXQ', _hash_type='md5', _accessor='AnnData', visibility=1, _key_is_virtual=True, storage_id=1, transform_id=17, run_id=79, created_by_id=2, created_at=2024-12-03 21:31:03 UTC)\n",
-      "Artifact(uid='O7CTVi6XjnfsceQ20000', is_latest=True, key='vitessce_examples/habib17.reference.json', description='Reference JSON for H5AD file, Habib et al., 2017 Nature Methods', suffix='.json', size=543575, hash='XFOV2X6Bw6_zTugTOEBehg', _hash_type='md5', visibility=1, _key_is_virtual=True, storage_id=1, transform_id=17, run_id=79, created_by_id=2, created_at=2024-12-03 21:31:14 UTC)\n",
-      "\u001b[93m!\u001b[0m returning existing collection with same hash: Collection(uid='obXokdzOnSH2tytJ0000', is_latest=True, name='View Habib17 (h5ad) in Vitessce', hash='U9WUAN_l9mLUWYqO2pJ9-g', visibility=1, created_by_id=2, transform_id=16, run_id=73, created_at=2024-12-03 21:33:48 UTC)\n",
-      "\u001b[92m→\u001b[0m returning existing artifact with same hash: Artifact(uid='ffUKrGJGNHL3TDhG0000', is_latest=True, description='View Habib17 (h5ad) in Vitessce', suffix='.vitessce.json', size=1365, hash='84eEO5D0fofN-0Sx47tCSA', _hash_type='md5', visibility=1, _key_is_virtual=True, storage_id=1, transform_id=15, run_id=74, created_by_id=2, created_at=2024-12-04 12:59:42 UTC)\n",
+      "Artifact(uid='1g3a41z0hggWNBrk0000', is_latest=True, key='vitessce_examples/habib17.h5ad', description='Habib et al., 2017 Nature Methods, h5ad', suffix='.h5ad', type='dataset', size=22586523, hash='-O1gvNOMqXm96TNFJ4yZXQ', _hash_type='md5', _accessor='AnnData', visibility=1, _key_is_virtual=True, storage_id=1, transform_id=18, run_id=85, created_by_id=2, created_at=2024-12-03 21:31:03 UTC)\n",
+      "Artifact(uid='O7CTVi6XjnfsceQ20000', is_latest=True, key='vitessce_examples/habib17.reference.json', description='Reference JSON for H5AD file, Habib et al., 2017 Nature Methods', suffix='.json', size=543575, hash='XFOV2X6Bw6_zTugTOEBehg', _hash_type='md5', visibility=1, _key_is_virtual=True, storage_id=1, transform_id=18, run_id=85, created_by_id=2, created_at=2024-12-03 21:31:14 UTC)\n",
+      "\u001b[93m!\u001b[0m returning existing collection with same hash: Collection(uid='obXokdzOnSH2tytJ0000', is_latest=True, name='View Habib17 (h5ad) in Vitessce', hash='U9WUAN_l9mLUWYqO2pJ9-g', visibility=1, created_by_id=2, transform_id=17, run_id=79, created_at=2024-12-03 21:33:48 UTC)\n",
+      "\u001b[92m→\u001b[0m returning existing artifact with same hash: Artifact(uid='ffUKrGJGNHL3TDhG0000', is_latest=True, description='View Habib17 (h5ad) in Vitessce', suffix='.vitessce.json', size=1365, hash='84eEO5D0fofN-0Sx47tCSA', _hash_type='md5', visibility=1, _key_is_virtual=True, storage_id=1, transform_id=15, run_id=80, created_by_id=2, created_at=2024-12-04 12:59:42 UTC)\n",
       "\u001b[92m→\u001b[0m VitessceConfig: https://lamin.ai/vitessce/examples/artifact/ffUKrGJGNHL3TDhG0000\n",
       "\u001b[92m→\u001b[0m Collection: https://lamin.ai/vitessce/examples/collection/obXokdzOnSH2tytJ0000\n"
      ]
@@ -353,8 +469,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 18,
-   "metadata": {},
+   "execution_count": 11,
+   "metadata": {
+    "editable": true,
+    "slideshow": {
+     "slide_type": ""
+    },
+    "tags": []
+   },
    "outputs": [
     {
      "data": {
@@ -378,18 +500,18 @@
        "<text text-anchor=\"start\" x=\"39.0947\" y=\"-175\" font-family=\"Monospace\" font-size=\"10.00\" fill=\"#c0c0c0\">uid=1g3a41z0hggWNBrk0000</text>\n",
        "<text text-anchor=\"start\" x=\"78.8457\" y=\"-165\" font-family=\"Monospace\" font-size=\"10.00\" fill=\"#c0c0c0\">suffix=.h5ad</text>\n",
        "</g>\n",
-       "<!-- run_CCFZLC4nNEr748iKG5Kz -->\n",
+       "<!-- run_14xlrpxdBiGrZAfL5oOg -->\n",
        "<g id=\"node2\" class=\"node\">\n",
-       "<title>run_CCFZLC4nNEr748iKG5Kz</title>\n",
-       "<path fill=\"#dcdcdc\" stroke=\"#065f46\" d=\"M313.428,-122C313.428,-122 184.4675,-122 184.4675,-122 178.4675,-122 172.4675,-116 172.4675,-110 172.4675,-110 172.4675,-86 172.4675,-86 172.4675,-80 178.4675,-74 184.4675,-74 184.4675,-74 313.428,-74 313.428,-74 319.428,-74 325.428,-80 325.428,-86 325.428,-86 325.428,-110 325.428,-110 325.428,-116 319.428,-122 313.428,-122\"/>\n",
+       "<title>run_14xlrpxdBiGrZAfL5oOg</title>\n",
+       "<path fill=\"#dcdcdc\" stroke=\"#065f46\" d=\"M312.6902,-122C312.6902,-122 185.2053,-122 185.2053,-122 179.2053,-122 173.2053,-116 173.2053,-110 173.2053,-110 173.2053,-86 173.2053,-86 173.2053,-80 179.2053,-74 185.2053,-74 185.2053,-74 312.6902,-74 312.6902,-74 318.6902,-74 324.6902,-80 324.6902,-86 324.6902,-86 324.6902,-110 324.6902,-110 324.6902,-116 318.6902,-122 312.6902,-122\"/>\n",
        "<text text-anchor=\"start\" x=\"193.5317\" y=\"-111\" font-family=\"Helvetica,sans-Serif\" font-size=\"10.00\" fill=\"#000000\">🔧 save_vitessce_config</text>\n",
        "<text text-anchor=\"start\" x=\"194.9731\" y=\"-101\" font-family=\"Monospace\" font-size=\"10.00\" fill=\"#c0c0c0\">uid=kup03MJBsIVa0002</text>\n",
        "<text text-anchor=\"start\" x=\"184.7461\" y=\"-91\" font-family=\"Monospace\" font-size=\"10.00\" fill=\"#c0c0c0\">type=function, user=mkeller7</text>\n",
-       "<text text-anchor=\"start\" x=\"180.708\" y=\"-81\" font-family=\"Monospace\" font-size=\"10.00\" fill=\"#c0c0c0\">run=2024&#45;12&#45;04 16:01:05 UTC</text>\n",
+       "<text text-anchor=\"start\" x=\"181.0767\" y=\"-81\" font-family=\"Monospace\" font-size=\"10.00\" fill=\"#c0c0c0\">run=2024&#45;12&#45;04 16:11:08 UTC</text>\n",
        "</g>\n",
-       "<!-- artifact_1g3a41z0hggWNBrk0000&#45;&gt;run_CCFZLC4nNEr748iKG5Kz -->\n",
+       "<!-- artifact_1g3a41z0hggWNBrk0000&#45;&gt;run_14xlrpxdBiGrZAfL5oOg -->\n",
        "<g id=\"edge1\" class=\"edge\">\n",
-       "<title>artifact_1g3a41z0hggWNBrk0000&#45;&gt;run_CCFZLC4nNEr748iKG5Kz</title>\n",
+       "<title>artifact_1g3a41z0hggWNBrk0000&#45;&gt;run_14xlrpxdBiGrZAfL5oOg</title>\n",
        "<path fill=\"none\" stroke=\"#696969\" d=\"M140.5641,-157.8763C158.6999,-147.8572 181.1955,-135.4296 200.9839,-124.4975\"/>\n",
        "<polygon fill=\"#696969\" stroke=\"#696969\" points=\"201.8938,-125.9942 205.4241,-122.0445 200.2013,-122.9306 201.8938,-125.9942\"/>\n",
        "</g>\n",
@@ -401,9 +523,9 @@
        "<text text-anchor=\"start\" x=\"180.5347\" y=\"-17\" font-family=\"Monospace\" font-size=\"10.00\" fill=\"#c0c0c0\">uid=ffUKrGJGNHL3TDhG0000</text>\n",
        "<text text-anchor=\"start\" x=\"204.3457\" y=\"-7\" font-family=\"Monospace\" font-size=\"10.00\" fill=\"#c0c0c0\">suffix=.vitessce.json</text>\n",
        "</g>\n",
-       "<!-- run_CCFZLC4nNEr748iKG5Kz&#45;&gt;artifact_ffUKrGJGNHL3TDhG0000 -->\n",
+       "<!-- run_14xlrpxdBiGrZAfL5oOg&#45;&gt;artifact_ffUKrGJGNHL3TDhG0000 -->\n",
        "<g id=\"edge3\" class=\"edge\">\n",
-       "<title>run_CCFZLC4nNEr748iKG5Kz&#45;&gt;artifact_ffUKrGJGNHL3TDhG0000</title>\n",
+       "<title>run_14xlrpxdBiGrZAfL5oOg&#45;&gt;artifact_ffUKrGJGNHL3TDhG0000</title>\n",
        "<path fill=\"none\" stroke=\"#696969\" d=\"M248.9478,-73.8681C248.9478,-64.2201 248.9478,-53.1228 248.9478,-43.4439\"/>\n",
        "<polygon fill=\"#696969\" stroke=\"#696969\" points=\"250.6978,-43.2308 248.9478,-38.2309 247.1978,-43.2309 250.6978,-43.2308\"/>\n",
        "</g>\n",
@@ -415,30 +537,30 @@
        "<text text-anchor=\"start\" x=\"327.6924\" y=\"-175\" font-family=\"Monospace\" font-size=\"10.00\" fill=\"#c0c0c0\">uid=O7CTVi6XjnfsceQ20000</text>\n",
        "<text text-anchor=\"start\" x=\"366.7964\" y=\"-165\" font-family=\"Monospace\" font-size=\"10.00\" fill=\"#c0c0c0\">suffix=.json</text>\n",
        "</g>\n",
-       "<!-- artifact_O7CTVi6XjnfsceQ20000&#45;&gt;run_CCFZLC4nNEr748iKG5Kz -->\n",
+       "<!-- artifact_O7CTVi6XjnfsceQ20000&#45;&gt;run_14xlrpxdBiGrZAfL5oOg -->\n",
        "<g id=\"edge2\" class=\"edge\">\n",
-       "<title>artifact_O7CTVi6XjnfsceQ20000&#45;&gt;run_CCFZLC4nNEr748iKG5Kz</title>\n",
+       "<title>artifact_O7CTVi6XjnfsceQ20000&#45;&gt;run_14xlrpxdBiGrZAfL5oOg</title>\n",
        "<path fill=\"none\" stroke=\"#696969\" d=\"M357.3314,-157.8763C339.1956,-147.8572 316.7,-135.4296 296.9117,-124.4975\"/>\n",
        "<polygon fill=\"#696969\" stroke=\"#696969\" points=\"297.6942,-122.9306 292.4714,-122.0445 296.0017,-125.9942 297.6942,-122.9306\"/>\n",
        "</g>\n",
-       "<!-- run_xt2ErUgo7KKqUOOAnVad -->\n",
+       "<!-- run_wW6GOHDq44lbrdKi08cr -->\n",
        "<g id=\"node5\" class=\"node\">\n",
-       "<title>run_xt2ErUgo7KKqUOOAnVad</title>\n",
+       "<title>run_wW6GOHDq44lbrdKi08cr</title>\n",
        "<path fill=\"#dcdcdc\" stroke=\"#065f46\" d=\"M456.428,-280C456.428,-280 327.4675,-280 327.4675,-280 321.4675,-280 315.4675,-274 315.4675,-268 315.4675,-268 315.4675,-244 315.4675,-244 315.4675,-238 321.4675,-232 327.4675,-232 327.4675,-232 456.428,-232 456.428,-232 462.428,-232 468.428,-238 468.428,-244 468.428,-244 468.428,-268 468.428,-268 468.428,-274 462.428,-280 456.428,-280\"/>\n",
        "<text text-anchor=\"start\" x=\"365.25\" y=\"-269\" font-family=\"Helvetica,sans-Serif\" font-size=\"10.00\" fill=\"#000000\">📔 Vitessce</text>\n",
-       "<text text-anchor=\"start\" x=\"333.7202\" y=\"-259\" font-family=\"Monospace\" font-size=\"10.00\" fill=\"#c0c0c0\">uid=XmcumVqvKZd30002</text>\n",
+       "<text text-anchor=\"start\" x=\"335.6685\" y=\"-259\" font-family=\"Monospace\" font-size=\"10.00\" fill=\"#c0c0c0\">uid=BZhZQ6uIbkWv0000</text>\n",
        "<text text-anchor=\"start\" x=\"324.6846\" y=\"-249\" font-family=\"Monospace\" font-size=\"10.00\" fill=\"#c0c0c0\">type=notebook, user=mkeller7</text>\n",
-       "<text text-anchor=\"start\" x=\"323.708\" y=\"-239\" font-family=\"Monospace\" font-size=\"10.00\" fill=\"#c0c0c0\">run=2024&#45;12&#45;04 16:00:56 UTC</text>\n",
+       "<text text-anchor=\"start\" x=\"323.708\" y=\"-239\" font-family=\"Monospace\" font-size=\"10.00\" fill=\"#c0c0c0\">run=2024&#45;12&#45;04 16:10:55 UTC</text>\n",
        "</g>\n",
-       "<!-- run_xt2ErUgo7KKqUOOAnVad&#45;&gt;artifact_1g3a41z0hggWNBrk0000 -->\n",
+       "<!-- run_wW6GOHDq44lbrdKi08cr&#45;&gt;artifact_1g3a41z0hggWNBrk0000 -->\n",
        "<g id=\"edge4\" class=\"edge\">\n",
-       "<title>run_xt2ErUgo7KKqUOOAnVad&#45;&gt;artifact_1g3a41z0hggWNBrk0000</title>\n",
+       "<title>run_wW6GOHDq44lbrdKi08cr&#45;&gt;artifact_1g3a41z0hggWNBrk0000</title>\n",
        "<path fill=\"none\" stroke=\"#696969\" d=\"M315.6807,-234.9332C273.7017,-223.3376 221.8323,-209.0101 180.1795,-197.5046\"/>\n",
        "<polygon fill=\"#696969\" stroke=\"#696969\" points=\"180.4374,-195.7603 175.1519,-196.1158 179.5054,-199.134 180.4374,-195.7603\"/>\n",
        "</g>\n",
-       "<!-- run_xt2ErUgo7KKqUOOAnVad&#45;&gt;artifact_O7CTVi6XjnfsceQ20000 -->\n",
+       "<!-- run_wW6GOHDq44lbrdKi08cr&#45;&gt;artifact_O7CTVi6XjnfsceQ20000 -->\n",
        "<g id=\"edge5\" class=\"edge\">\n",
-       "<title>run_xt2ErUgo7KKqUOOAnVad&#45;&gt;artifact_O7CTVi6XjnfsceQ20000</title>\n",
+       "<title>run_wW6GOHDq44lbrdKi08cr&#45;&gt;artifact_O7CTVi6XjnfsceQ20000</title>\n",
        "<path fill=\"none\" stroke=\"#696969\" d=\"M391.9478,-231.8681C391.9478,-222.2201 391.9478,-211.1228 391.9478,-201.4439\"/>\n",
        "<polygon fill=\"#696969\" stroke=\"#696969\" points=\"393.6978,-201.2308 391.9478,-196.2309 390.1978,-201.2309 393.6978,-201.2308\"/>\n",
        "</g>\n",
@@ -450,9 +572,9 @@
        "<text text-anchor=\"start\" x=\"595.5996\" y=\"-175\" font-family=\"Monospace\" font-size=\"10.00\" fill=\"#c0c0c0\">uid=obXokdzOnSH2tytJ0000</text>\n",
        "<text text-anchor=\"start\" x=\"628.9565\" y=\"-165\" font-family=\"Monospace\" font-size=\"10.00\" fill=\"#c0c0c0\">version=None</text>\n",
        "</g>\n",
-       "<!-- run_xt2ErUgo7KKqUOOAnVad&#45;&gt;collection_obXokdzOnSH2tytJ0000 -->\n",
+       "<!-- run_wW6GOHDq44lbrdKi08cr&#45;&gt;collection_obXokdzOnSH2tytJ0000 -->\n",
        "<g id=\"edge6\" class=\"edge\">\n",
-       "<title>run_xt2ErUgo7KKqUOOAnVad&#45;&gt;collection_obXokdzOnSH2tytJ0000</title>\n",
+       "<title>run_wW6GOHDq44lbrdKi08cr&#45;&gt;collection_obXokdzOnSH2tytJ0000</title>\n",
        "<path fill=\"none\" stroke=\"#696969\" d=\"M468.3871,-233.4675C506.7362,-222.1631 552.851,-208.5696 590.2243,-197.5528\"/>\n",
        "<polygon fill=\"#696969\" stroke=\"#696969\" points=\"590.9028,-199.1773 595.2039,-196.0849 589.9131,-195.8201 590.9028,-199.1773\"/>\n",
        "</g>\n",
@@ -470,7 +592,13 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "editable": true,
+    "slideshow": {
+     "slide_type": ""
+    },
+    "tags": []
+   },
    "source": [
     ":::{note}\n",
     "\n",
@@ -484,36 +612,66 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "editable": true,
+    "slideshow": {
+     "slide_type": ""
+    },
+    "tags": []
+   },
    "source": [
     "## Visualize an AnnData object (Zarr format)"
    ]
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "editable": true,
+    "slideshow": {
+     "slide_type": ""
+    },
+    "tags": []
+   },
    "source": [
     "AnnData objects can be saved on-disk to not only `.h5ad` files, but also to [Zarr stores](https://zarr.readthedocs.io/en/stable/tutorial.html#storage-alternatives) using AnnData's [write_zarr](https://anndata.readthedocs.io/en/latest/generated/anndata.AnnData.write_zarr.html) method."
    ]
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "editable": true,
+    "slideshow": {
+     "slide_type": ""
+    },
+    "tags": []
+   },
    "source": [
     "### Save the dataset"
    ]
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "editable": true,
+    "slideshow": {
+     "slide_type": ""
+    },
+    "tags": []
+   },
    "source": [
     "Convert the dataset to `.zarr` format. Often, Zarr data is stored on-disk using a [DirectoryStore](https://zarr.readthedocs.io/en/stable/api/storage.html#zarr.storage.DirectoryStore). By convention, these directories are named using a `.zarr` suffix."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 19,
-   "metadata": {},
+   "execution_count": 12,
+   "metadata": {
+    "editable": true,
+    "slideshow": {
+     "slide_type": ""
+    },
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "zarr_processed_filepath = \"./habib17.anndata.zarr\""
@@ -521,8 +679,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 20,
-   "metadata": {},
+   "execution_count": 13,
+   "metadata": {
+    "editable": true,
+    "slideshow": {
+     "slide_type": ""
+    },
+    "tags": []
+   },
    "outputs": [
     {
      "name": "stderr",
@@ -545,15 +709,27 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "editable": true,
+    "slideshow": {
+     "slide_type": ""
+    },
+    "tags": []
+   },
    "source": [
     "Just like in the above section, we may want to modify the AnnData object prior to saving it as a LaminDB Artifact that we will use for visualization."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 21,
-   "metadata": {},
+   "execution_count": 14,
+   "metadata": {
+    "editable": true,
+    "slideshow": {
+     "slide_type": ""
+    },
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "adata = adata[:, adata.var[\"highly_variable\"]].copy()"
@@ -561,15 +737,27 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "editable": true,
+    "slideshow": {
+     "slide_type": ""
+    },
+    "tags": []
+   },
    "source": [
     "Note the usage of `.write_zarr` below, as opposed to `.write_h5ad`."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 22,
-   "metadata": {},
+   "execution_count": 15,
+   "metadata": {
+    "editable": true,
+    "slideshow": {
+     "slide_type": ""
+    },
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "adata.write_zarr(zarr_processed_filepath)"
@@ -577,16 +765,27 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "editable": true,
+    "slideshow": {
+     "slide_type": ""
+    },
+    "tags": []
+   },
    "source": [
     "Save the `.zarr` directory as a LaminDB Artifact."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 24,
+   "execution_count": 16,
    "metadata": {
-    "scrolled": true
+    "editable": true,
+    "scrolled": true,
+    "slideshow": {
+     "slide_type": ""
+    },
+    "tags": []
    },
    "outputs": [
     {
@@ -599,10 +798,10 @@
     {
      "data": {
       "text/plain": [
-       "Artifact(uid='kWwG45Hr26KZUW3g0004', is_latest=True, key='vitessce_examples/habib17.adata.zarr', description='Habib et al., 2017 Nature Methods, zarr', suffix='.anndata.zarr', type='dataset', size=10601062, hash='Ap_EL5yPdfyD07Xjpe1SlA', n_objects=208, _hash_type='md5-d', _accessor='AnnData', visibility=1, _key_is_virtual=True, storage_id=1, transform_id=17, run_id=79, created_by_id=2, created_at=2024-12-04 16:01:11 UTC)"
+       "Artifact(uid='kWwG45Hr26KZUW3g0004', is_latest=True, key='vitessce_examples/habib17.adata.zarr', description='Habib et al., 2017 Nature Methods, zarr', suffix='.anndata.zarr', type='dataset', size=10601062, hash='Ap_EL5yPdfyD07Xjpe1SlA', n_objects=208, _hash_type='md5-d', _accessor='AnnData', visibility=1, _key_is_virtual=True, storage_id=1, transform_id=18, run_id=85, created_by_id=2, created_at=2024-12-04 16:01:11 UTC)"
       ]
      },
-     "execution_count": 24,
+     "execution_count": 16,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -619,14 +818,26 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "editable": true,
+    "slideshow": {
+     "slide_type": ""
+    },
+    "tags": []
+   },
    "source": [
     "### Save a VitessceConfig object"
    ]
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "editable": true,
+    "slideshow": {
+     "slide_type": ""
+    },
+    "tags": []
+   },
    "source": [
     "You can create a dashboard for one or several datasets by using Vitessce's component API.\n",
     "Here, we configure the visualization the same way as above in the `.h5ad`-based example, with the exception of the `ref_artifact` parameter, as `.zarr`-based AnnData objects do not require a Reference Specification for Zarr interoperability."
@@ -634,8 +845,12 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 25,
+   "execution_count": 17,
    "metadata": {
+    "editable": true,
+    "slideshow": {
+     "slide_type": ""
+    },
     "tags": [
      "hide-output"
     ]
@@ -667,15 +882,25 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "editable": true,
+    "slideshow": {
+     "slide_type": ""
+    },
+    "tags": []
+   },
    "source": [
     "Save the `VitessceConfig` object."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 26,
+   "execution_count": 18,
    "metadata": {
+    "editable": true,
+    "slideshow": {
+     "slide_type": ""
+    },
     "tags": [
      "hide-output"
     ]
@@ -686,8 +911,8 @@
      "output_type": "stream",
      "text": [
       "\u001b[92m→\u001b[0m VitessceConfig references these artifacts:\n",
-      "Artifact(uid='kWwG45Hr26KZUW3g0004', is_latest=True, key='vitessce_examples/habib17.adata.zarr', description='Habib et al., 2017 Nature Methods, zarr', suffix='.anndata.zarr', type='dataset', size=10601062, hash='Ap_EL5yPdfyD07Xjpe1SlA', n_objects=208, _hash_type='md5-d', _accessor='AnnData', visibility=1, _key_is_virtual=True, storage_id=1, transform_id=17, run_id=79, created_by_id=2, created_at=2024-12-04 16:01:11 UTC)\n",
-      "\u001b[92m→\u001b[0m returning existing artifact with same hash: Artifact(uid='J4tMB6qAeHvsgEsp0000', is_latest=True, description='View Habib17 in Vitessce', suffix='.vitessce.json', size=1247, hash='MN-N-I_cn9K8Y2Pe59u1Fw', _hash_type='md5', visibility=1, _key_is_virtual=True, storage_id=1, transform_id=15, run_id=75, created_by_id=2, created_at=2024-12-04 14:32:11 UTC)\n",
+      "Artifact(uid='kWwG45Hr26KZUW3g0004', is_latest=True, key='vitessce_examples/habib17.adata.zarr', description='Habib et al., 2017 Nature Methods, zarr', suffix='.anndata.zarr', type='dataset', size=10601062, hash='Ap_EL5yPdfyD07Xjpe1SlA', n_objects=208, _hash_type='md5-d', _accessor='AnnData', visibility=1, _key_is_virtual=True, storage_id=1, transform_id=18, run_id=85, created_by_id=2, created_at=2024-12-04 16:01:11 UTC)\n",
+      "\u001b[92m→\u001b[0m returning existing artifact with same hash: Artifact(uid='J4tMB6qAeHvsgEsp0000', is_latest=True, description='View Habib17 in Vitessce', suffix='.vitessce.json', size=1247, hash='MN-N-I_cn9K8Y2Pe59u1Fw', _hash_type='md5', visibility=1, _key_is_virtual=True, storage_id=1, transform_id=15, run_id=81, created_by_id=2, created_at=2024-12-04 14:32:11 UTC)\n",
       "\u001b[92m→\u001b[0m VitessceConfig: https://lamin.ai/vitessce/examples/artifact/J4tMB6qAeHvsgEsp0000\n",
       "\u001b[92m→\u001b[0m Dataset: https://lamin.ai/vitessce/examples/artifact/kWwG45Hr26KZUW3g0004\n"
      ]
@@ -701,8 +926,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 27,
-   "metadata": {},
+   "execution_count": 19,
+   "metadata": {
+    "editable": true,
+    "slideshow": {
+     "slide_type": ""
+    },
+    "tags": []
+   },
    "outputs": [
     {
      "data": {
@@ -726,18 +957,18 @@
        "<text text-anchor=\"start\" x=\"31.3213\" y=\"-175\" font-family=\"Monospace\" font-size=\"10.00\" fill=\"#c0c0c0\">uid=kWwG45Hr26KZUW3g0004</text>\n",
        "<text text-anchor=\"start\" x=\"59.3828\" y=\"-165\" font-family=\"Monospace\" font-size=\"10.00\" fill=\"#c0c0c0\">suffix=.anndata.zarr</text>\n",
        "</g>\n",
-       "<!-- run_xZ9HuVQ66i2OBqKlXQ5F -->\n",
+       "<!-- run_xdpOXGoyQMEMPv19bfbw -->\n",
        "<g id=\"node2\" class=\"node\">\n",
-       "<title>run_xZ9HuVQ66i2OBqKlXQ5F</title>\n",
-       "<path fill=\"#dcdcdc\" stroke=\"#065f46\" d=\"M167.9158,-122C167.9158,-122 38.9553,-122 38.9553,-122 32.9553,-122 26.9553,-116 26.9553,-110 26.9553,-110 26.9553,-86 26.9553,-86 26.9553,-80 32.9553,-74 38.9553,-74 38.9553,-74 167.9158,-74 167.9158,-74 173.9158,-74 179.9158,-80 179.9158,-86 179.9158,-86 179.9158,-110 179.9158,-110 179.9158,-116 173.9158,-122 167.9158,-122\"/>\n",
+       "<title>run_xdpOXGoyQMEMPv19bfbw</title>\n",
+       "<path fill=\"#dcdcdc\" stroke=\"#065f46\" d=\"M167.178,-122C167.178,-122 39.6931,-122 39.6931,-122 33.6931,-122 27.6931,-116 27.6931,-110 27.6931,-110 27.6931,-86 27.6931,-86 27.6931,-80 33.6931,-74 39.6931,-74 39.6931,-74 167.178,-74 167.178,-74 173.178,-74 179.178,-80 179.178,-86 179.178,-86 179.178,-110 179.178,-110 179.178,-116 173.178,-122 167.178,-122\"/>\n",
        "<text text-anchor=\"start\" x=\"48.0195\" y=\"-111\" font-family=\"Helvetica,sans-Serif\" font-size=\"10.00\" fill=\"#000000\">🔧 save_vitessce_config</text>\n",
        "<text text-anchor=\"start\" x=\"49.4609\" y=\"-101\" font-family=\"Monospace\" font-size=\"10.00\" fill=\"#c0c0c0\">uid=kup03MJBsIVa0002</text>\n",
        "<text text-anchor=\"start\" x=\"39.2339\" y=\"-91\" font-family=\"Monospace\" font-size=\"10.00\" fill=\"#c0c0c0\">type=function, user=mkeller7</text>\n",
-       "<text text-anchor=\"start\" x=\"35.1958\" y=\"-81\" font-family=\"Monospace\" font-size=\"10.00\" fill=\"#c0c0c0\">run=2024&#45;12&#45;04 16:01:25 UTC</text>\n",
+       "<text text-anchor=\"start\" x=\"35.5645\" y=\"-81\" font-family=\"Monospace\" font-size=\"10.00\" fill=\"#c0c0c0\">run=2024&#45;12&#45;04 16:11:24 UTC</text>\n",
        "</g>\n",
-       "<!-- artifact_kWwG45Hr26KZUW3g0004&#45;&gt;run_xZ9HuVQ66i2OBqKlXQ5F -->\n",
+       "<!-- artifact_kWwG45Hr26KZUW3g0004&#45;&gt;run_xdpOXGoyQMEMPv19bfbw -->\n",
        "<g id=\"edge1\" class=\"edge\">\n",
-       "<title>artifact_kWwG45Hr26KZUW3g0004&#45;&gt;run_xZ9HuVQ66i2OBqKlXQ5F</title>\n",
+       "<title>artifact_kWwG45Hr26KZUW3g0004&#45;&gt;run_xdpOXGoyQMEMPv19bfbw</title>\n",
        "<path fill=\"none\" stroke=\"#696969\" d=\"M103.4355,-157.8763C103.4355,-148.6991 103.4355,-137.5013 103.4355,-127.2829\"/>\n",
        "<polygon fill=\"#696969\" stroke=\"#696969\" points=\"105.1856,-127.0445 103.4355,-122.0445 101.6856,-127.0445 105.1856,-127.0445\"/>\n",
        "</g>\n",
@@ -749,24 +980,24 @@
        "<text text-anchor=\"start\" x=\"36.8657\" y=\"-17\" font-family=\"Monospace\" font-size=\"10.00\" fill=\"#c0c0c0\">uid=J4tMB6qAeHvsgEsp0000</text>\n",
        "<text text-anchor=\"start\" x=\"58.8335\" y=\"-7\" font-family=\"Monospace\" font-size=\"10.00\" fill=\"#c0c0c0\">suffix=.vitessce.json</text>\n",
        "</g>\n",
-       "<!-- run_xZ9HuVQ66i2OBqKlXQ5F&#45;&gt;artifact_J4tMB6qAeHvsgEsp0000 -->\n",
+       "<!-- run_xdpOXGoyQMEMPv19bfbw&#45;&gt;artifact_J4tMB6qAeHvsgEsp0000 -->\n",
        "<g id=\"edge2\" class=\"edge\">\n",
-       "<title>run_xZ9HuVQ66i2OBqKlXQ5F&#45;&gt;artifact_J4tMB6qAeHvsgEsp0000</title>\n",
+       "<title>run_xdpOXGoyQMEMPv19bfbw&#45;&gt;artifact_J4tMB6qAeHvsgEsp0000</title>\n",
        "<path fill=\"none\" stroke=\"#696969\" d=\"M103.4355,-73.8681C103.4355,-64.2201 103.4355,-53.1228 103.4355,-43.4439\"/>\n",
        "<polygon fill=\"#696969\" stroke=\"#696969\" points=\"105.1856,-43.2308 103.4355,-38.2309 101.6856,-43.2309 105.1856,-43.2308\"/>\n",
        "</g>\n",
-       "<!-- run_xt2ErUgo7KKqUOOAnVad -->\n",
+       "<!-- run_wW6GOHDq44lbrdKi08cr -->\n",
        "<g id=\"node4\" class=\"node\">\n",
-       "<title>run_xt2ErUgo7KKqUOOAnVad</title>\n",
+       "<title>run_wW6GOHDq44lbrdKi08cr</title>\n",
        "<path fill=\"#dcdcdc\" stroke=\"#065f46\" d=\"M537.9158,-280C537.9158,-280 408.9553,-280 408.9553,-280 402.9553,-280 396.9553,-274 396.9553,-268 396.9553,-268 396.9553,-244 396.9553,-244 396.9553,-238 402.9553,-232 408.9553,-232 408.9553,-232 537.9158,-232 537.9158,-232 543.9158,-232 549.9158,-238 549.9158,-244 549.9158,-244 549.9158,-268 549.9158,-268 549.9158,-274 543.9158,-280 537.9158,-280\"/>\n",
        "<text text-anchor=\"start\" x=\"446.7378\" y=\"-269\" font-family=\"Helvetica,sans-Serif\" font-size=\"10.00\" fill=\"#000000\">📔 Vitessce</text>\n",
-       "<text text-anchor=\"start\" x=\"415.208\" y=\"-259\" font-family=\"Monospace\" font-size=\"10.00\" fill=\"#c0c0c0\">uid=XmcumVqvKZd30002</text>\n",
+       "<text text-anchor=\"start\" x=\"417.1563\" y=\"-259\" font-family=\"Monospace\" font-size=\"10.00\" fill=\"#c0c0c0\">uid=BZhZQ6uIbkWv0000</text>\n",
        "<text text-anchor=\"start\" x=\"406.1724\" y=\"-249\" font-family=\"Monospace\" font-size=\"10.00\" fill=\"#c0c0c0\">type=notebook, user=mkeller7</text>\n",
-       "<text text-anchor=\"start\" x=\"405.1958\" y=\"-239\" font-family=\"Monospace\" font-size=\"10.00\" fill=\"#c0c0c0\">run=2024&#45;12&#45;04 16:00:56 UTC</text>\n",
+       "<text text-anchor=\"start\" x=\"405.1958\" y=\"-239\" font-family=\"Monospace\" font-size=\"10.00\" fill=\"#c0c0c0\">run=2024&#45;12&#45;04 16:10:55 UTC</text>\n",
        "</g>\n",
-       "<!-- run_xt2ErUgo7KKqUOOAnVad&#45;&gt;artifact_kWwG45Hr26KZUW3g0004 -->\n",
+       "<!-- run_wW6GOHDq44lbrdKi08cr&#45;&gt;artifact_kWwG45Hr26KZUW3g0004 -->\n",
        "<g id=\"edge5\" class=\"edge\">\n",
-       "<title>run_xt2ErUgo7KKqUOOAnVad&#45;&gt;artifact_kWwG45Hr26KZUW3g0004</title>\n",
+       "<title>run_wW6GOHDq44lbrdKi08cr&#45;&gt;artifact_kWwG45Hr26KZUW3g0004</title>\n",
        "<path fill=\"none\" stroke=\"#696969\" d=\"M396.7713,-239.6311C339.0212,-227.3007 259.5247,-210.3271 197.856,-197.16\"/>\n",
        "<polygon fill=\"#696969\" stroke=\"#696969\" points=\"197.9534,-195.3915 192.6982,-196.0588 197.2225,-198.8143 197.9534,-195.3915\"/>\n",
        "</g>\n",
@@ -778,9 +1009,9 @@
        "<text text-anchor=\"start\" x=\"263.5825\" y=\"-175\" font-family=\"Monospace\" font-size=\"10.00\" fill=\"#c0c0c0\">uid=1g3a41z0hggWNBrk0000</text>\n",
        "<text text-anchor=\"start\" x=\"303.3335\" y=\"-165\" font-family=\"Monospace\" font-size=\"10.00\" fill=\"#c0c0c0\">suffix=.h5ad</text>\n",
        "</g>\n",
-       "<!-- run_xt2ErUgo7KKqUOOAnVad&#45;&gt;artifact_1g3a41z0hggWNBrk0000 -->\n",
+       "<!-- run_wW6GOHDq44lbrdKi08cr&#45;&gt;artifact_1g3a41z0hggWNBrk0000 -->\n",
        "<g id=\"edge3\" class=\"edge\">\n",
-       "<title>run_xt2ErUgo7KKqUOOAnVad&#45;&gt;artifact_1g3a41z0hggWNBrk0000</title>\n",
+       "<title>run_wW6GOHDq44lbrdKi08cr&#45;&gt;artifact_1g3a41z0hggWNBrk0000</title>\n",
        "<path fill=\"none\" stroke=\"#696969\" d=\"M429.7538,-231.8681C410.6726,-221.3267 388.4598,-209.0553 369.8856,-198.7941\"/>\n",
        "<polygon fill=\"#696969\" stroke=\"#696969\" points=\"370.4687,-197.1169 365.2458,-196.2309 368.7762,-200.1805 370.4687,-197.1169\"/>\n",
        "</g>\n",
@@ -792,9 +1023,9 @@
        "<text text-anchor=\"start\" x=\"552.1802\" y=\"-175\" font-family=\"Monospace\" font-size=\"10.00\" fill=\"#c0c0c0\">uid=O7CTVi6XjnfsceQ20000</text>\n",
        "<text text-anchor=\"start\" x=\"591.2842\" y=\"-165\" font-family=\"Monospace\" font-size=\"10.00\" fill=\"#c0c0c0\">suffix=.json</text>\n",
        "</g>\n",
-       "<!-- run_xt2ErUgo7KKqUOOAnVad&#45;&gt;artifact_O7CTVi6XjnfsceQ20000 -->\n",
+       "<!-- run_wW6GOHDq44lbrdKi08cr&#45;&gt;artifact_O7CTVi6XjnfsceQ20000 -->\n",
        "<g id=\"edge4\" class=\"edge\">\n",
-       "<title>run_xt2ErUgo7KKqUOOAnVad&#45;&gt;artifact_O7CTVi6XjnfsceQ20000</title>\n",
+       "<title>run_wW6GOHDq44lbrdKi08cr&#45;&gt;artifact_O7CTVi6XjnfsceQ20000</title>\n",
        "<path fill=\"none\" stroke=\"#696969\" d=\"M517.1173,-231.8681C536.1985,-221.3267 558.4113,-209.0553 576.9855,-198.7941\"/>\n",
        "<polygon fill=\"#696969\" stroke=\"#696969\" points=\"578.0949,-200.1805 581.6252,-196.2309 576.4024,-197.1169 578.0949,-200.1805\"/>\n",
        "</g>\n",
@@ -806,9 +1037,9 @@
        "<text text-anchor=\"start\" x=\"820.0874\" y=\"-175\" font-family=\"Monospace\" font-size=\"10.00\" fill=\"#c0c0c0\">uid=obXokdzOnSH2tytJ0000</text>\n",
        "<text text-anchor=\"start\" x=\"853.4443\" y=\"-165\" font-family=\"Monospace\" font-size=\"10.00\" fill=\"#c0c0c0\">version=None</text>\n",
        "</g>\n",
-       "<!-- run_xt2ErUgo7KKqUOOAnVad&#45;&gt;collection_obXokdzOnSH2tytJ0000 -->\n",
+       "<!-- run_wW6GOHDq44lbrdKi08cr&#45;&gt;collection_obXokdzOnSH2tytJ0000 -->\n",
        "<g id=\"edge6\" class=\"edge\">\n",
-       "<title>run_xt2ErUgo7KKqUOOAnVad&#45;&gt;collection_obXokdzOnSH2tytJ0000</title>\n",
+       "<title>run_wW6GOHDq44lbrdKi08cr&#45;&gt;collection_obXokdzOnSH2tytJ0000</title>\n",
        "<path fill=\"none\" stroke=\"#696969\" d=\"M549.9149,-241.4884C613.5076,-229.3973 706.3822,-211.6821 787.4355,-196 788.7255,-195.7504 790.025,-195.4988 791.3324,-195.2454\"/>\n",
        "<polygon fill=\"#696969\" stroke=\"#696969\" points=\"791.8353,-196.9306 796.4106,-194.2604 791.1688,-193.4946 791.8353,-196.9306\"/>\n",
        "</g>\n",
@@ -826,7 +1057,13 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "editable": true,
+    "slideshow": {
+     "slide_type": ""
+    },
+    "tags": []
+   },
    "source": [
     ":::{note}\n",
     "\n",
@@ -837,22 +1074,40 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "editable": true,
+    "slideshow": {
+     "slide_type": ""
+    },
+    "tags": []
+   },
    "source": [
     "## Visualize a SpatialData object (Zarr format)"
    ]
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "editable": true,
+    "slideshow": {
+     "slide_type": ""
+    },
+    "tags": []
+   },
    "source": [
     "Download and unzip the example SpatialData dataset (approximately 1.47 GB unzipped). Once unzipped, the data will be available via a local Zarr DirectoryStore."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 28,
-   "metadata": {},
+   "execution_count": 20,
+   "metadata": {
+    "editable": true,
+    "slideshow": {
+     "slide_type": ""
+    },
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "sdata_zip_filepath = \"./visium.spatialdata.zarr.zip\"\n",
@@ -870,39 +1125,56 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "editable": true,
+    "slideshow": {
+     "slide_type": ""
+    },
+    "tags": []
+   },
    "source": [
     "### Save the dataset"
    ]
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "editable": true,
+    "slideshow": {
+     "slide_type": ""
+    },
+    "tags": []
+   },
    "source": [
     "Save the `.zarr` DirectoryStore as a LaminDB Artifact."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 29,
+   "execution_count": 21,
    "metadata": {
-    "scrolled": true
+    "editable": true,
+    "scrolled": true,
+    "slideshow": {
+     "slide_type": ""
+    },
+    "tags": []
    },
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[92m→\u001b[0m returning existing artifact with same hash: Artifact(uid='nelDyBfwvEIIAKcC0000', is_latest=True, key='vitessce_examples/visium.sdata.zarr', description='Visium SpatialData Example', suffix='.zarr', type='dataset', size=1473180201, hash='BkflAMTiin88wE3Wc84rDQ', n_objects=9167, _hash_type='md5-d', visibility=1, _key_is_virtual=True, storage_id=1, transform_id=16, run_id=73, created_by_id=2, created_at=2024-12-04 13:25:22 UTC)\n"
+      "\u001b[92m→\u001b[0m returning existing artifact with same hash: Artifact(uid='nelDyBfwvEIIAKcC0000', is_latest=True, key='vitessce_examples/visium.sdata.zarr', description='Visium SpatialData Example', suffix='.zarr', type='dataset', size=1473180201, hash='BkflAMTiin88wE3Wc84rDQ', n_objects=9167, _hash_type='md5-d', visibility=1, _key_is_virtual=True, storage_id=1, transform_id=17, run_id=79, created_by_id=2, created_at=2024-12-04 13:25:22 UTC)\n"
      ]
     },
     {
      "data": {
       "text/plain": [
-       "Artifact(uid='nelDyBfwvEIIAKcC0000', is_latest=True, key='vitessce_examples/visium.sdata.zarr', description='Visium SpatialData Example', suffix='.zarr', type='dataset', size=1473180201, hash='BkflAMTiin88wE3Wc84rDQ', n_objects=9167, _hash_type='md5-d', visibility=1, _key_is_virtual=True, storage_id=1, transform_id=17, run_id=79, created_by_id=2, created_at=2024-12-04 13:25:22 UTC)"
+       "Artifact(uid='nelDyBfwvEIIAKcC0000', is_latest=True, key='vitessce_examples/visium.sdata.zarr', description='Visium SpatialData Example', suffix='.zarr', type='dataset', size=1473180201, hash='BkflAMTiin88wE3Wc84rDQ', n_objects=9167, _hash_type='md5-d', visibility=1, _key_is_virtual=True, storage_id=1, transform_id=18, run_id=85, created_by_id=2, created_at=2024-12-04 13:25:22 UTC)"
       ]
      },
-     "execution_count": 29,
+     "execution_count": 21,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -919,14 +1191,26 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "editable": true,
+    "slideshow": {
+     "slide_type": ""
+    },
+    "tags": []
+   },
    "source": [
     "### Save a VitessceConfig object"
    ]
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "editable": true,
+    "slideshow": {
+     "slide_type": ""
+    },
+    "tags": []
+   },
    "source": [
     "You can create a dashboard for one or several datasets by using Vitessce's component API.\n",
     "Here, we use the [SpatialDataWrapper](https://python-docs.vitessce.io/api_data.html#vitessce.wrappers.SpatialDataWrapper) class to specify which parts of the SpatialData object will be loaded for visualization."
@@ -934,8 +1218,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 30,
-   "metadata": {},
+   "execution_count": 22,
+   "metadata": {
+    "editable": true,
+    "slideshow": {
+     "slide_type": ""
+    },
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "vc = vit.VitessceConfig(\n",
@@ -980,15 +1270,25 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "editable": true,
+    "slideshow": {
+     "slide_type": ""
+    },
+    "tags": []
+   },
    "source": [
     "Save the `VitessceConfig` object."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 31,
+   "execution_count": 23,
    "metadata": {
+    "editable": true,
+    "slideshow": {
+     "slide_type": ""
+    },
     "tags": [
      "hide-output"
     ]
@@ -999,8 +1299,8 @@
      "output_type": "stream",
      "text": [
       "\u001b[92m→\u001b[0m VitessceConfig references these artifacts:\n",
-      "Artifact(uid='nelDyBfwvEIIAKcC0000', is_latest=True, key='vitessce_examples/visium.sdata.zarr', description='Visium SpatialData Example', suffix='.zarr', type='dataset', size=1473180201, hash='BkflAMTiin88wE3Wc84rDQ', n_objects=9167, _hash_type='md5-d', visibility=1, _key_is_virtual=True, storage_id=1, transform_id=17, run_id=79, created_by_id=2, created_at=2024-12-04 13:25:22 UTC)\n",
-      "\u001b[92m→\u001b[0m returning existing artifact with same hash: Artifact(uid='Xot2a5ZAcTW3fClG0000', is_latest=True, description='View Visium SpatialData Example in Vitessce', suffix='.vitessce.json', size=1845, hash='PirnTDMPxYDC9ajti_St4g', _hash_type='md5', visibility=1, _key_is_virtual=True, storage_id=1, transform_id=15, run_id=76, created_by_id=2, created_at=2024-12-04 15:53:06 UTC)\n",
+      "Artifact(uid='nelDyBfwvEIIAKcC0000', is_latest=True, key='vitessce_examples/visium.sdata.zarr', description='Visium SpatialData Example', suffix='.zarr', type='dataset', size=1473180201, hash='BkflAMTiin88wE3Wc84rDQ', n_objects=9167, _hash_type='md5-d', visibility=1, _key_is_virtual=True, storage_id=1, transform_id=18, run_id=85, created_by_id=2, created_at=2024-12-04 13:25:22 UTC)\n",
+      "\u001b[92m→\u001b[0m returning existing artifact with same hash: Artifact(uid='Xot2a5ZAcTW3fClG0000', is_latest=True, description='View Visium SpatialData Example in Vitessce', suffix='.vitessce.json', size=1845, hash='PirnTDMPxYDC9ajti_St4g', _hash_type='md5', visibility=1, _key_is_virtual=True, storage_id=1, transform_id=15, run_id=82, created_by_id=2, created_at=2024-12-04 15:53:06 UTC)\n",
       "\u001b[92m→\u001b[0m VitessceConfig: https://lamin.ai/vitessce/examples/artifact/Xot2a5ZAcTW3fClG0000\n",
       "\u001b[92m→\u001b[0m Dataset: https://lamin.ai/vitessce/examples/artifact/nelDyBfwvEIIAKcC0000\n"
      ]
@@ -1014,8 +1314,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 32,
-   "metadata": {},
+   "execution_count": 24,
+   "metadata": {
+    "editable": true,
+    "slideshow": {
+     "slide_type": ""
+    },
+    "tags": []
+   },
    "outputs": [
     {
      "data": {
@@ -1039,18 +1345,18 @@
        "<text text-anchor=\"start\" x=\"53.2744\" y=\"-175\" font-family=\"Monospace\" font-size=\"10.00\" fill=\"#c0c0c0\">uid=nelDyBfwvEIIAKcC0000</text>\n",
        "<text text-anchor=\"start\" x=\"91.9121\" y=\"-165\" font-family=\"Monospace\" font-size=\"10.00\" fill=\"#c0c0c0\">suffix=.zarr</text>\n",
        "</g>\n",
-       "<!-- run_yE0u9JC40liWx6H7jfAT -->\n",
+       "<!-- run_8rJ3LFQ1zd5gJLiWRXGV -->\n",
        "<g id=\"node2\" class=\"node\">\n",
-       "<title>run_yE0u9JC40liWx6H7jfAT</title>\n",
-       "<path fill=\"#dcdcdc\" stroke=\"#065f46\" d=\"M180.9822,-122C180.9822,-122 52.0217,-122 52.0217,-122 46.0217,-122 40.0217,-116 40.0217,-110 40.0217,-110 40.0217,-86 40.0217,-86 40.0217,-80 46.0217,-74 52.0217,-74 52.0217,-74 180.9822,-74 180.9822,-74 186.9822,-74 192.9822,-80 192.9822,-86 192.9822,-86 192.9822,-110 192.9822,-110 192.9822,-116 186.9822,-122 180.9822,-122\"/>\n",
+       "<title>run_8rJ3LFQ1zd5gJLiWRXGV</title>\n",
+       "<path fill=\"#dcdcdc\" stroke=\"#065f46\" d=\"M180.2444,-122C180.2444,-122 52.7595,-122 52.7595,-122 46.7595,-122 40.7595,-116 40.7595,-110 40.7595,-110 40.7595,-86 40.7595,-86 40.7595,-80 46.7595,-74 52.7595,-74 52.7595,-74 180.2444,-74 180.2444,-74 186.2444,-74 192.2444,-80 192.2444,-86 192.2444,-86 192.2444,-110 192.2444,-110 192.2444,-116 186.2444,-122 180.2444,-122\"/>\n",
        "<text text-anchor=\"start\" x=\"61.0859\" y=\"-111\" font-family=\"Helvetica,sans-Serif\" font-size=\"10.00\" fill=\"#000000\">🔧 save_vitessce_config</text>\n",
        "<text text-anchor=\"start\" x=\"62.5273\" y=\"-101\" font-family=\"Monospace\" font-size=\"10.00\" fill=\"#c0c0c0\">uid=kup03MJBsIVa0002</text>\n",
        "<text text-anchor=\"start\" x=\"52.3003\" y=\"-91\" font-family=\"Monospace\" font-size=\"10.00\" fill=\"#c0c0c0\">type=function, user=mkeller7</text>\n",
-       "<text text-anchor=\"start\" x=\"48.2622\" y=\"-81\" font-family=\"Monospace\" font-size=\"10.00\" fill=\"#c0c0c0\">run=2024&#45;12&#45;04 16:01:32 UTC</text>\n",
+       "<text text-anchor=\"start\" x=\"48.6309\" y=\"-81\" font-family=\"Monospace\" font-size=\"10.00\" fill=\"#c0c0c0\">run=2024&#45;12&#45;04 16:11:34 UTC</text>\n",
        "</g>\n",
-       "<!-- artifact_nelDyBfwvEIIAKcC0000&#45;&gt;run_yE0u9JC40liWx6H7jfAT -->\n",
+       "<!-- artifact_nelDyBfwvEIIAKcC0000&#45;&gt;run_8rJ3LFQ1zd5gJLiWRXGV -->\n",
        "<g id=\"edge1\" class=\"edge\">\n",
-       "<title>artifact_nelDyBfwvEIIAKcC0000&#45;&gt;run_yE0u9JC40liWx6H7jfAT</title>\n",
+       "<title>artifact_nelDyBfwvEIIAKcC0000&#45;&gt;run_8rJ3LFQ1zd5gJLiWRXGV</title>\n",
        "<path fill=\"none\" stroke=\"#696969\" d=\"M116.502,-157.8763C116.502,-148.6991 116.502,-137.5013 116.502,-127.2829\"/>\n",
        "<polygon fill=\"#696969\" stroke=\"#696969\" points=\"118.252,-127.0445 116.502,-122.0445 114.752,-127.0445 118.252,-127.0445\"/>\n",
        "</g>\n",
@@ -1062,24 +1368,24 @@
        "<text text-anchor=\"start\" x=\"50.4961\" y=\"-17\" font-family=\"Monospace\" font-size=\"10.00\" fill=\"#c0c0c0\">uid=Xot2a5ZAcTW3fClG0000</text>\n",
        "<text text-anchor=\"start\" x=\"71.8999\" y=\"-7\" font-family=\"Monospace\" font-size=\"10.00\" fill=\"#c0c0c0\">suffix=.vitessce.json</text>\n",
        "</g>\n",
-       "<!-- run_yE0u9JC40liWx6H7jfAT&#45;&gt;artifact_Xot2a5ZAcTW3fClG0000 -->\n",
+       "<!-- run_8rJ3LFQ1zd5gJLiWRXGV&#45;&gt;artifact_Xot2a5ZAcTW3fClG0000 -->\n",
        "<g id=\"edge2\" class=\"edge\">\n",
-       "<title>run_yE0u9JC40liWx6H7jfAT&#45;&gt;artifact_Xot2a5ZAcTW3fClG0000</title>\n",
+       "<title>run_8rJ3LFQ1zd5gJLiWRXGV&#45;&gt;artifact_Xot2a5ZAcTW3fClG0000</title>\n",
        "<path fill=\"none\" stroke=\"#696969\" d=\"M116.502,-73.8681C116.502,-64.2201 116.502,-53.1228 116.502,-43.4439\"/>\n",
        "<polygon fill=\"#696969\" stroke=\"#696969\" points=\"118.252,-43.2308 116.502,-38.2309 114.752,-43.2309 118.252,-43.2308\"/>\n",
        "</g>\n",
-       "<!-- run_xt2ErUgo7KKqUOOAnVad -->\n",
+       "<!-- run_wW6GOHDq44lbrdKi08cr -->\n",
        "<g id=\"node4\" class=\"node\">\n",
-       "<title>run_xt2ErUgo7KKqUOOAnVad</title>\n",
+       "<title>run_wW6GOHDq44lbrdKi08cr</title>\n",
        "<path fill=\"#dcdcdc\" stroke=\"#065f46\" d=\"M669.9822,-280C669.9822,-280 541.0217,-280 541.0217,-280 535.0217,-280 529.0217,-274 529.0217,-268 529.0217,-268 529.0217,-244 529.0217,-244 529.0217,-238 535.0217,-232 541.0217,-232 541.0217,-232 669.9822,-232 669.9822,-232 675.9822,-232 681.9822,-238 681.9822,-244 681.9822,-244 681.9822,-268 681.9822,-268 681.9822,-274 675.9822,-280 669.9822,-280\"/>\n",
        "<text text-anchor=\"start\" x=\"578.8042\" y=\"-269\" font-family=\"Helvetica,sans-Serif\" font-size=\"10.00\" fill=\"#000000\">📔 Vitessce</text>\n",
-       "<text text-anchor=\"start\" x=\"547.2744\" y=\"-259\" font-family=\"Monospace\" font-size=\"10.00\" fill=\"#c0c0c0\">uid=XmcumVqvKZd30002</text>\n",
+       "<text text-anchor=\"start\" x=\"549.2227\" y=\"-259\" font-family=\"Monospace\" font-size=\"10.00\" fill=\"#c0c0c0\">uid=BZhZQ6uIbkWv0000</text>\n",
        "<text text-anchor=\"start\" x=\"538.2388\" y=\"-249\" font-family=\"Monospace\" font-size=\"10.00\" fill=\"#c0c0c0\">type=notebook, user=mkeller7</text>\n",
-       "<text text-anchor=\"start\" x=\"537.2622\" y=\"-239\" font-family=\"Monospace\" font-size=\"10.00\" fill=\"#c0c0c0\">run=2024&#45;12&#45;04 16:00:56 UTC</text>\n",
+       "<text text-anchor=\"start\" x=\"537.2622\" y=\"-239\" font-family=\"Monospace\" font-size=\"10.00\" fill=\"#c0c0c0\">run=2024&#45;12&#45;04 16:10:55 UTC</text>\n",
        "</g>\n",
-       "<!-- run_xt2ErUgo7KKqUOOAnVad&#45;&gt;artifact_nelDyBfwvEIIAKcC0000 -->\n",
-       "<g id=\"edge3\" class=\"edge\">\n",
-       "<title>run_xt2ErUgo7KKqUOOAnVad&#45;&gt;artifact_nelDyBfwvEIIAKcC0000</title>\n",
+       "<!-- run_wW6GOHDq44lbrdKi08cr&#45;&gt;artifact_nelDyBfwvEIIAKcC0000 -->\n",
+       "<g id=\"edge5\" class=\"edge\">\n",
+       "<title>run_wW6GOHDq44lbrdKi08cr&#45;&gt;artifact_nelDyBfwvEIIAKcC0000</title>\n",
        "<path fill=\"none\" stroke=\"#696969\" d=\"M529.1332,-246.057C448.2745,-235.1829 317.0306,-216.5447 204.502,-196 203.2239,-195.7667 201.936,-195.5284 200.6403,-195.2859\"/>\n",
        "<polygon fill=\"#696969\" stroke=\"#696969\" points=\"200.847,-193.5439 195.6082,-194.3302 200.1938,-196.9825 200.847,-193.5439\"/>\n",
        "</g>\n",
@@ -1091,9 +1397,9 @@
        "<text text-anchor=\"start\" x=\"252.6489\" y=\"-175\" font-family=\"Monospace\" font-size=\"10.00\" fill=\"#c0c0c0\">uid=1g3a41z0hggWNBrk0000</text>\n",
        "<text text-anchor=\"start\" x=\"292.3999\" y=\"-165\" font-family=\"Monospace\" font-size=\"10.00\" fill=\"#c0c0c0\">suffix=.h5ad</text>\n",
        "</g>\n",
-       "<!-- run_xt2ErUgo7KKqUOOAnVad&#45;&gt;artifact_1g3a41z0hggWNBrk0000 -->\n",
-       "<g id=\"edge4\" class=\"edge\">\n",
-       "<title>run_xt2ErUgo7KKqUOOAnVad&#45;&gt;artifact_1g3a41z0hggWNBrk0000</title>\n",
+       "<!-- run_wW6GOHDq44lbrdKi08cr&#45;&gt;artifact_1g3a41z0hggWNBrk0000 -->\n",
+       "<g id=\"edge3\" class=\"edge\">\n",
+       "<title>run_wW6GOHDq44lbrdKi08cr&#45;&gt;artifact_1g3a41z0hggWNBrk0000</title>\n",
        "<path fill=\"none\" stroke=\"#696969\" d=\"M529.2349,-234.9332C487.2559,-223.3376 435.3865,-209.0101 393.7337,-197.5046\"/>\n",
        "<polygon fill=\"#696969\" stroke=\"#696969\" points=\"393.9916,-195.7603 388.7061,-196.1158 393.0596,-199.134 393.9916,-195.7603\"/>\n",
        "</g>\n",
@@ -1105,9 +1411,9 @@
        "<text text-anchor=\"start\" x=\"541.2466\" y=\"-175\" font-family=\"Monospace\" font-size=\"10.00\" fill=\"#c0c0c0\">uid=O7CTVi6XjnfsceQ20000</text>\n",
        "<text text-anchor=\"start\" x=\"580.3506\" y=\"-165\" font-family=\"Monospace\" font-size=\"10.00\" fill=\"#c0c0c0\">suffix=.json</text>\n",
        "</g>\n",
-       "<!-- run_xt2ErUgo7KKqUOOAnVad&#45;&gt;artifact_O7CTVi6XjnfsceQ20000 -->\n",
-       "<g id=\"edge5\" class=\"edge\">\n",
-       "<title>run_xt2ErUgo7KKqUOOAnVad&#45;&gt;artifact_O7CTVi6XjnfsceQ20000</title>\n",
+       "<!-- run_wW6GOHDq44lbrdKi08cr&#45;&gt;artifact_O7CTVi6XjnfsceQ20000 -->\n",
+       "<g id=\"edge4\" class=\"edge\">\n",
+       "<title>run_wW6GOHDq44lbrdKi08cr&#45;&gt;artifact_O7CTVi6XjnfsceQ20000</title>\n",
        "<path fill=\"none\" stroke=\"#696969\" d=\"M605.502,-231.8681C605.502,-222.2201 605.502,-211.1228 605.502,-201.4439\"/>\n",
        "<polygon fill=\"#696969\" stroke=\"#696969\" points=\"607.252,-201.2308 605.502,-196.2309 603.752,-201.2309 607.252,-201.2308\"/>\n",
        "</g>\n",
@@ -1119,9 +1425,9 @@
        "<text text-anchor=\"start\" x=\"817.3877\" y=\"-175\" font-family=\"Monospace\" font-size=\"10.00\" fill=\"#c0c0c0\">uid=kWwG45Hr26KZUW3g0004</text>\n",
        "<text text-anchor=\"start\" x=\"845.4492\" y=\"-165\" font-family=\"Monospace\" font-size=\"10.00\" fill=\"#c0c0c0\">suffix=.anndata.zarr</text>\n",
        "</g>\n",
-       "<!-- run_xt2ErUgo7KKqUOOAnVad&#45;&gt;artifact_kWwG45Hr26KZUW3g0004 -->\n",
+       "<!-- run_wW6GOHDq44lbrdKi08cr&#45;&gt;artifact_kWwG45Hr26KZUW3g0004 -->\n",
        "<g id=\"edge6\" class=\"edge\">\n",
-       "<title>run_xt2ErUgo7KKqUOOAnVad&#45;&gt;artifact_kWwG45Hr26KZUW3g0004</title>\n",
+       "<title>run_wW6GOHDq44lbrdKi08cr&#45;&gt;artifact_kWwG45Hr26KZUW3g0004</title>\n",
        "<path fill=\"none\" stroke=\"#696969\" d=\"M681.9823,-234.7255C723.6607,-223.1319 774.984,-208.8553 816.1623,-197.4008\"/>\n",
        "<polygon fill=\"#696969\" stroke=\"#696969\" points=\"816.7843,-199.0443 821.1324,-196.0183 815.8463,-195.6723 816.7843,-199.0443\"/>\n",
        "</g>\n",
@@ -1133,9 +1439,9 @@
        "<text text-anchor=\"start\" x=\"1034.1538\" y=\"-175\" font-family=\"Monospace\" font-size=\"10.00\" fill=\"#c0c0c0\">uid=obXokdzOnSH2tytJ0000</text>\n",
        "<text text-anchor=\"start\" x=\"1067.5107\" y=\"-165\" font-family=\"Monospace\" font-size=\"10.00\" fill=\"#c0c0c0\">version=None</text>\n",
        "</g>\n",
-       "<!-- run_xt2ErUgo7KKqUOOAnVad&#45;&gt;collection_obXokdzOnSH2tytJ0000 -->\n",
+       "<!-- run_wW6GOHDq44lbrdKi08cr&#45;&gt;collection_obXokdzOnSH2tytJ0000 -->\n",
        "<g id=\"edge7\" class=\"edge\">\n",
-       "<title>run_xt2ErUgo7KKqUOOAnVad&#45;&gt;collection_obXokdzOnSH2tytJ0000</title>\n",
+       "<title>run_wW6GOHDq44lbrdKi08cr&#45;&gt;collection_obXokdzOnSH2tytJ0000</title>\n",
        "<path fill=\"none\" stroke=\"#696969\" d=\"M681.9452,-245.4134C761.8162,-234.1191 890.6873,-215.2388 1001.502,-196 1002.7964,-195.7753 1004.1002,-195.547 1005.4116,-195.3155\"/>\n",
        "<polygon fill=\"#696969\" stroke=\"#696969\" points=\"1005.8886,-197.0082 1010.5041,-194.4082 1005.2746,-193.5625 1005.8886,-197.0082\"/>\n",
        "</g>\n",
@@ -1153,7 +1459,13 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "editable": true,
+    "slideshow": {
+     "slide_type": ""
+    },
+    "tags": []
+   },
    "source": [
     ":::{note}\n",
     "\n",
@@ -1164,29 +1476,53 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "editable": true,
+    "slideshow": {
+     "slide_type": ""
+    },
+    "tags": []
+   },
    "source": [
     "## Visualize an image (OME-TIFF format)"
    ]
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "editable": true,
+    "slideshow": {
+     "slide_type": ""
+    },
+    "tags": []
+   },
    "source": [
     "Vitesse can visualize data from multiple bioimaging file formats, including [OME-TIFF](https://ome-model.readthedocs.io/en/stable/ome-tiff/)."
    ]
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "editable": true,
+    "slideshow": {
+     "slide_type": ""
+    },
+    "tags": []
+   },
    "source": [
     "Here, we download an example OME-TIFF file (approximately 1.02 GB)."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 33,
-   "metadata": {},
+   "execution_count": 25,
+   "metadata": {
+    "editable": true,
+    "slideshow": {
+     "slide_type": ""
+    },
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "ome_tiff_filepath = \"./VAN0006-LK-2-85-PAS_registered.ome.tif\"\n",
@@ -1199,37 +1535,55 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "editable": true,
+    "slideshow": {
+     "slide_type": ""
+    },
+    "tags": []
+   },
    "source": [
     "### Save the dataset"
    ]
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "editable": true,
+    "slideshow": {
+     "slide_type": ""
+    },
+    "tags": []
+   },
    "source": [
     "Save the `.ome.tif` file as a LaminDB Artifact."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 34,
-   "metadata": {},
+   "execution_count": 26,
+   "metadata": {
+    "editable": true,
+    "slideshow": {
+     "slide_type": ""
+    },
+    "tags": []
+   },
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[92m→\u001b[0m returning existing artifact with same hash: Artifact(uid='0I5aMNdh2UrECtFX0000', is_latest=True, key='vitessce_examples/VAN0006-LK-2-85-PAS_registered.ome.tif', description='PAS OME-TIFF file, Neumann et al., 2020', suffix='.tif', type='dataset', size=1021561156, hash='pa3FYqKL6afG8PduprhRJk', _hash_type='sha1-fl', visibility=1, _key_is_virtual=True, storage_id=1, transform_id=16, run_id=73, created_by_id=2, created_at=2024-10-05 20:00:49 UTC)\n"
+      "\u001b[92m→\u001b[0m returning existing artifact with same hash: Artifact(uid='0I5aMNdh2UrECtFX0000', is_latest=True, key='vitessce_examples/VAN0006-LK-2-85-PAS_registered.ome.tif', description='PAS OME-TIFF file, Neumann et al., 2020', suffix='.tif', type='dataset', size=1021561156, hash='pa3FYqKL6afG8PduprhRJk', _hash_type='sha1-fl', visibility=1, _key_is_virtual=True, storage_id=1, transform_id=17, run_id=79, created_by_id=2, created_at=2024-10-05 20:00:49 UTC)\n"
      ]
     },
     {
      "data": {
       "text/plain": [
-       "Artifact(uid='0I5aMNdh2UrECtFX0000', is_latest=True, key='vitessce_examples/VAN0006-LK-2-85-PAS_registered.ome.tif', description='PAS OME-TIFF file, Neumann et al., 2020', suffix='.tif', type='dataset', size=1021561156, hash='pa3FYqKL6afG8PduprhRJk', _hash_type='sha1-fl', visibility=1, _key_is_virtual=True, storage_id=1, transform_id=17, run_id=79, created_by_id=2, created_at=2024-10-05 20:00:49 UTC)"
+       "Artifact(uid='0I5aMNdh2UrECtFX0000', is_latest=True, key='vitessce_examples/VAN0006-LK-2-85-PAS_registered.ome.tif', description='PAS OME-TIFF file, Neumann et al., 2020', suffix='.tif', type='dataset', size=1021561156, hash='pa3FYqKL6afG8PduprhRJk', _hash_type='sha1-fl', visibility=1, _key_is_virtual=True, storage_id=1, transform_id=18, run_id=85, created_by_id=2, created_at=2024-10-05 20:00:49 UTC)"
       ]
      },
-     "execution_count": 34,
+     "execution_count": 26,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1246,15 +1600,27 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "editable": true,
+    "slideshow": {
+     "slide_type": ""
+    },
+    "tags": []
+   },
    "source": [
     "When using OME-TIFF files, we can use [generate-tiff-offsets](https://github.com/hms-dbmi/generate-tiff-offsets) to create an index for the bytes within the OME-TIFF file. We store these to a companion `.offsets.json` file which makes loading subsets of the image more efficient."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 35,
-   "metadata": {},
+   "execution_count": 27,
+   "metadata": {
+    "editable": true,
+    "slideshow": {
+     "slide_type": ""
+    },
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "offsets = get_offsets(ome_tiff_filepath)"
@@ -1262,14 +1628,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 36,
-   "metadata": {},
+   "execution_count": 28,
+   "metadata": {
+    "editable": true,
+    "slideshow": {
+     "slide_type": ""
+    },
+    "tags": []
+   },
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[92m→\u001b[0m returning existing artifact with same hash: Artifact(uid='CMBUzbNNCEDGCKcQ0000', is_latest=True, key='vitessce_examples/VAN0006-LK-2-85-PAS_registered.offsets.json', description='PAS offsets file, Neumann et al., 2020', suffix='.json', type='dataset', size=36, hash='5ADv5d7DI5oYVaMOPnhqiw', _hash_type='md5', visibility=1, _key_is_virtual=True, storage_id=1, transform_id=16, run_id=73, created_by_id=2, created_at=2024-10-05 20:18:38 UTC)\n"
+      "\u001b[92m→\u001b[0m returning existing artifact with same hash: Artifact(uid='CMBUzbNNCEDGCKcQ0000', is_latest=True, key='vitessce_examples/VAN0006-LK-2-85-PAS_registered.offsets.json', description='PAS offsets file, Neumann et al., 2020', suffix='.json', type='dataset', size=36, hash='5ADv5d7DI5oYVaMOPnhqiw', _hash_type='md5', visibility=1, _key_is_virtual=True, storage_id=1, transform_id=17, run_id=79, created_by_id=2, created_at=2024-10-05 20:18:38 UTC)\n"
      ]
     }
    ],
@@ -1286,14 +1658,26 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "editable": true,
+    "slideshow": {
+     "slide_type": ""
+    },
+    "tags": []
+   },
    "source": [
     "### Save a VitessceConfig object"
    ]
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "editable": true,
+    "slideshow": {
+     "slide_type": ""
+    },
+    "tags": []
+   },
    "source": [
     "You can create a dashboard for one or several datasets by using Vitessce's component API.\n",
     "Here, we use the [ImageOmeTiffWrapper](https://python-docs.vitessce.io/api_data.html#vitessce.wrappers.ImageOmeTiffWrapper) class to specify which pair of OME-TIFF file and offsets JSON file to load."
@@ -1301,8 +1685,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 37,
-   "metadata": {},
+   "execution_count": 29,
+   "metadata": {
+    "editable": true,
+    "slideshow": {
+     "slide_type": ""
+    },
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "vc = vit.VitessceConfig(\n",
@@ -1322,15 +1712,25 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "editable": true,
+    "slideshow": {
+     "slide_type": ""
+    },
+    "tags": []
+   },
    "source": [
     "Save the `VitessceConfig` object."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 38,
+   "execution_count": 30,
    "metadata": {
+    "editable": true,
+    "slideshow": {
+     "slide_type": ""
+    },
     "tags": [
      "hide-output"
     ]
@@ -1341,10 +1741,10 @@
      "output_type": "stream",
      "text": [
       "\u001b[92m→\u001b[0m VitessceConfig references these artifacts:\n",
-      "Artifact(uid='0I5aMNdh2UrECtFX0000', is_latest=True, key='vitessce_examples/VAN0006-LK-2-85-PAS_registered.ome.tif', description='PAS OME-TIFF file, Neumann et al., 2020', suffix='.tif', type='dataset', size=1021561156, hash='pa3FYqKL6afG8PduprhRJk', _hash_type='sha1-fl', visibility=1, _key_is_virtual=True, storage_id=1, transform_id=17, run_id=79, created_by_id=2, created_at=2024-10-05 20:00:49 UTC)\n",
-      "Artifact(uid='CMBUzbNNCEDGCKcQ0000', is_latest=True, key='vitessce_examples/VAN0006-LK-2-85-PAS_registered.offsets.json', description='PAS offsets file, Neumann et al., 2020', suffix='.json', type='dataset', size=36, hash='5ADv5d7DI5oYVaMOPnhqiw', _hash_type='md5', visibility=1, _key_is_virtual=True, storage_id=1, transform_id=17, run_id=79, created_by_id=2, created_at=2024-10-05 20:18:38 UTC)\n",
-      "\u001b[93m!\u001b[0m returning existing collection with same hash: Collection(uid='HqfzZmkfYOy20ZNN0000', is_latest=True, name='View PAS OME-TIFF, Neumann et al., 2020 in Vitessce', hash='vpleElXxZiaZblQ09q9K-g', visibility=1, created_by_id=2, transform_id=16, run_id=73, created_at=2024-10-05 20:49:25 UTC)\n",
-      "\u001b[92m→\u001b[0m returning existing artifact with same hash: Artifact(uid='QtF1OEtYyUe1EQ1k0000', is_latest=True, description='View PAS OME-TIFF, Neumann et al., 2020 in Vitessce', suffix='.vitessce.json', size=724, hash='SzO9Fq5iH2Xhz76j-qTjvg', _hash_type='md5', visibility=1, _key_is_virtual=True, storage_id=1, transform_id=15, run_id=77, created_by_id=2, created_at=2024-12-04 14:34:20 UTC)\n",
+      "Artifact(uid='0I5aMNdh2UrECtFX0000', is_latest=True, key='vitessce_examples/VAN0006-LK-2-85-PAS_registered.ome.tif', description='PAS OME-TIFF file, Neumann et al., 2020', suffix='.tif', type='dataset', size=1021561156, hash='pa3FYqKL6afG8PduprhRJk', _hash_type='sha1-fl', visibility=1, _key_is_virtual=True, storage_id=1, transform_id=18, run_id=85, created_by_id=2, created_at=2024-10-05 20:00:49 UTC)\n",
+      "Artifact(uid='CMBUzbNNCEDGCKcQ0000', is_latest=True, key='vitessce_examples/VAN0006-LK-2-85-PAS_registered.offsets.json', description='PAS offsets file, Neumann et al., 2020', suffix='.json', type='dataset', size=36, hash='5ADv5d7DI5oYVaMOPnhqiw', _hash_type='md5', visibility=1, _key_is_virtual=True, storage_id=1, transform_id=18, run_id=85, created_by_id=2, created_at=2024-10-05 20:18:38 UTC)\n",
+      "\u001b[93m!\u001b[0m returning existing collection with same hash: Collection(uid='HqfzZmkfYOy20ZNN0000', is_latest=True, name='View PAS OME-TIFF, Neumann et al., 2020 in Vitessce', hash='vpleElXxZiaZblQ09q9K-g', visibility=1, created_by_id=2, transform_id=17, run_id=79, created_at=2024-10-05 20:49:25 UTC)\n",
+      "\u001b[92m→\u001b[0m returning existing artifact with same hash: Artifact(uid='QtF1OEtYyUe1EQ1k0000', is_latest=True, description='View PAS OME-TIFF, Neumann et al., 2020 in Vitessce', suffix='.vitessce.json', size=724, hash='SzO9Fq5iH2Xhz76j-qTjvg', _hash_type='md5', visibility=1, _key_is_virtual=True, storage_id=1, transform_id=15, run_id=83, created_by_id=2, created_at=2024-12-04 14:34:20 UTC)\n",
       "\u001b[92m→\u001b[0m VitessceConfig: https://lamin.ai/vitessce/examples/artifact/QtF1OEtYyUe1EQ1k0000\n",
       "\u001b[92m→\u001b[0m Collection: https://lamin.ai/vitessce/examples/collection/HqfzZmkfYOy20ZNN0000\n"
      ]
@@ -1358,8 +1758,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 39,
-   "metadata": {},
+   "execution_count": 31,
+   "metadata": {
+    "editable": true,
+    "slideshow": {
+     "slide_type": ""
+    },
+    "tags": []
+   },
    "outputs": [
     {
      "data": {
@@ -1370,11 +1776,11 @@
        "<!-- Generated by graphviz version 2.40.1 (20161225.0304)\n",
        " -->\n",
        "<!-- Title: artifact_QtF1OEtYyUe1EQ1k0000 Pages: 1 -->\n",
-       "<svg width=\"1905pt\" height=\"288pt\"\n",
-       " viewBox=\"0.00 0.00 1905.06 288.00\" xmlns=\"http://www.w3.org/2000/svg\" xmlns:xlink=\"http://www.w3.org/1999/xlink\">\n",
+       "<svg width=\"1904pt\" height=\"288pt\"\n",
+       " viewBox=\"0.00 0.00 1904.06 288.00\" xmlns=\"http://www.w3.org/2000/svg\" xmlns:xlink=\"http://www.w3.org/1999/xlink\">\n",
        "<g id=\"graph0\" class=\"graph\" transform=\"scale(1 1) rotate(0) translate(4 284)\">\n",
        "<title>artifact_QtF1OEtYyUe1EQ1k0000</title>\n",
-       "<polygon fill=\"#ffffff\" stroke=\"transparent\" points=\"-4,4 -4,-284 1901.0615,-284 1901.0615,4 -4,4\"/>\n",
+       "<polygon fill=\"#ffffff\" stroke=\"transparent\" points=\"-4,4 -4,-284 1900.0615,-284 1900.0615,4 -4,4\"/>\n",
        "<!-- artifact_0I5aMNdh2UrECtFX0000 -->\n",
        "<g id=\"node1\" class=\"node\">\n",
        "<title>artifact_0I5aMNdh2UrECtFX0000</title>\n",
@@ -1383,18 +1789,18 @@
        "<text text-anchor=\"start\" x=\"42.3247\" y=\"-175\" font-family=\"Monospace\" font-size=\"10.00\" fill=\"#c0c0c0\">uid=0I5aMNdh2UrECtFX0000</text>\n",
        "<text text-anchor=\"start\" x=\"89.0215\" y=\"-165\" font-family=\"Monospace\" font-size=\"10.00\" fill=\"#c0c0c0\">suffix=.tif</text>\n",
        "</g>\n",
-       "<!-- run_DZlFDV3T7syiFOXMkcHn -->\n",
+       "<!-- run_PWGWyCcRk4ZAUWxNBeiJ -->\n",
        "<g id=\"node2\" class=\"node\">\n",
-       "<title>run_DZlFDV3T7syiFOXMkcHn</title>\n",
-       "<path fill=\"#dcdcdc\" stroke=\"#065f46\" d=\"M286.3699,-122C286.3699,-122 157.4094,-122 157.4094,-122 151.4094,-122 145.4094,-116 145.4094,-110 145.4094,-110 145.4094,-86 145.4094,-86 145.4094,-80 151.4094,-74 157.4094,-74 157.4094,-74 286.3699,-74 286.3699,-74 292.3699,-74 298.3699,-80 298.3699,-86 298.3699,-86 298.3699,-110 298.3699,-110 298.3699,-116 292.3699,-122 286.3699,-122\"/>\n",
+       "<title>run_PWGWyCcRk4ZAUWxNBeiJ</title>\n",
+       "<path fill=\"#dcdcdc\" stroke=\"#065f46\" d=\"M285.6321,-122C285.6321,-122 158.1472,-122 158.1472,-122 152.1472,-122 146.1472,-116 146.1472,-110 146.1472,-110 146.1472,-86 146.1472,-86 146.1472,-80 152.1472,-74 158.1472,-74 158.1472,-74 285.6321,-74 285.6321,-74 291.6321,-74 297.6321,-80 297.6321,-86 297.6321,-86 297.6321,-110 297.6321,-110 297.6321,-116 291.6321,-122 285.6321,-122\"/>\n",
        "<text text-anchor=\"start\" x=\"166.4736\" y=\"-111\" font-family=\"Helvetica,sans-Serif\" font-size=\"10.00\" fill=\"#000000\">🔧 save_vitessce_config</text>\n",
        "<text text-anchor=\"start\" x=\"167.915\" y=\"-101\" font-family=\"Monospace\" font-size=\"10.00\" fill=\"#c0c0c0\">uid=kup03MJBsIVa0002</text>\n",
        "<text text-anchor=\"start\" x=\"157.688\" y=\"-91\" font-family=\"Monospace\" font-size=\"10.00\" fill=\"#c0c0c0\">type=function, user=mkeller7</text>\n",
-       "<text text-anchor=\"start\" x=\"153.6499\" y=\"-81\" font-family=\"Monospace\" font-size=\"10.00\" fill=\"#c0c0c0\">run=2024&#45;12&#45;04 16:01:38 UTC</text>\n",
+       "<text text-anchor=\"start\" x=\"154.0186\" y=\"-81\" font-family=\"Monospace\" font-size=\"10.00\" fill=\"#c0c0c0\">run=2024&#45;12&#45;04 16:11:43 UTC</text>\n",
        "</g>\n",
-       "<!-- artifact_0I5aMNdh2UrECtFX0000&#45;&gt;run_DZlFDV3T7syiFOXMkcHn -->\n",
+       "<!-- artifact_0I5aMNdh2UrECtFX0000&#45;&gt;run_PWGWyCcRk4ZAUWxNBeiJ -->\n",
        "<g id=\"edge1\" class=\"edge\">\n",
-       "<title>artifact_0I5aMNdh2UrECtFX0000&#45;&gt;run_DZlFDV3T7syiFOXMkcHn</title>\n",
+       "<title>artifact_0I5aMNdh2UrECtFX0000&#45;&gt;run_PWGWyCcRk4ZAUWxNBeiJ</title>\n",
        "<path fill=\"none\" stroke=\"#696969\" d=\"M136.2438,-157.8763C150.3341,-148.0256 167.7546,-135.8466 183.1979,-125.05\"/>\n",
        "<polygon fill=\"#696969\" stroke=\"#696969\" points=\"184.4017,-126.3437 187.4969,-122.0445 182.3963,-123.4752 184.4017,-126.3437\"/>\n",
        "</g>\n",
@@ -1406,9 +1812,9 @@
        "<text text-anchor=\"start\" x=\"153.9355\" y=\"-17\" font-family=\"Monospace\" font-size=\"10.00\" fill=\"#c0c0c0\">uid=QtF1OEtYyUe1EQ1k0000</text>\n",
        "<text text-anchor=\"start\" x=\"177.2876\" y=\"-7\" font-family=\"Monospace\" font-size=\"10.00\" fill=\"#c0c0c0\">suffix=.vitessce.json</text>\n",
        "</g>\n",
-       "<!-- run_DZlFDV3T7syiFOXMkcHn&#45;&gt;artifact_QtF1OEtYyUe1EQ1k0000 -->\n",
+       "<!-- run_PWGWyCcRk4ZAUWxNBeiJ&#45;&gt;artifact_QtF1OEtYyUe1EQ1k0000 -->\n",
        "<g id=\"edge3\" class=\"edge\">\n",
-       "<title>run_DZlFDV3T7syiFOXMkcHn&#45;&gt;artifact_QtF1OEtYyUe1EQ1k0000</title>\n",
+       "<title>run_PWGWyCcRk4ZAUWxNBeiJ&#45;&gt;artifact_QtF1OEtYyUe1EQ1k0000</title>\n",
        "<path fill=\"none\" stroke=\"#696969\" d=\"M221.8896,-73.8681C221.8896,-64.2201 221.8896,-53.1228 221.8896,-43.4439\"/>\n",
        "<polygon fill=\"#696969\" stroke=\"#696969\" points=\"223.6397,-43.2308 221.8896,-38.2309 220.1397,-43.2309 223.6397,-43.2308\"/>\n",
        "</g>\n",
@@ -1420,116 +1826,116 @@
        "<text text-anchor=\"start\" x=\"260.1694\" y=\"-175\" font-family=\"Monospace\" font-size=\"10.00\" fill=\"#c0c0c0\">uid=CMBUzbNNCEDGCKcQ0000</text>\n",
        "<text text-anchor=\"start\" x=\"310.7383\" y=\"-165\" font-family=\"Monospace\" font-size=\"10.00\" fill=\"#c0c0c0\">suffix=.json</text>\n",
        "</g>\n",
-       "<!-- artifact_CMBUzbNNCEDGCKcQ0000&#45;&gt;run_DZlFDV3T7syiFOXMkcHn -->\n",
+       "<!-- artifact_CMBUzbNNCEDGCKcQ0000&#45;&gt;run_PWGWyCcRk4ZAUWxNBeiJ -->\n",
        "<g id=\"edge2\" class=\"edge\">\n",
-       "<title>artifact_CMBUzbNNCEDGCKcQ0000&#45;&gt;run_DZlFDV3T7syiFOXMkcHn</title>\n",
+       "<title>artifact_CMBUzbNNCEDGCKcQ0000&#45;&gt;run_PWGWyCcRk4ZAUWxNBeiJ</title>\n",
        "<path fill=\"none\" stroke=\"#696969\" d=\"M308.2934,-157.8763C294.0785,-148.0256 276.5038,-135.8466 260.9238,-125.05\"/>\n",
        "<polygon fill=\"#696969\" stroke=\"#696969\" points=\"261.6933,-123.4541 256.5868,-122.0445 259.6997,-126.3309 261.6933,-123.4541\"/>\n",
        "</g>\n",
-       "<!-- run_xt2ErUgo7KKqUOOAnVad -->\n",
+       "<!-- run_wW6GOHDq44lbrdKi08cr -->\n",
        "<g id=\"node5\" class=\"node\">\n",
-       "<title>run_xt2ErUgo7KKqUOOAnVad</title>\n",
-       "<path fill=\"#dcdcdc\" stroke=\"#065f46\" d=\"M943.3699,-280C943.3699,-280 814.4094,-280 814.4094,-280 808.4094,-280 802.4094,-274 802.4094,-268 802.4094,-268 802.4094,-244 802.4094,-244 802.4094,-238 808.4094,-232 814.4094,-232 814.4094,-232 943.3699,-232 943.3699,-232 949.3699,-232 955.3699,-238 955.3699,-244 955.3699,-244 955.3699,-268 955.3699,-268 955.3699,-274 949.3699,-280 943.3699,-280\"/>\n",
-       "<text text-anchor=\"start\" x=\"852.1919\" y=\"-269\" font-family=\"Helvetica,sans-Serif\" font-size=\"10.00\" fill=\"#000000\">📔 Vitessce</text>\n",
-       "<text text-anchor=\"start\" x=\"820.6621\" y=\"-259\" font-family=\"Monospace\" font-size=\"10.00\" fill=\"#c0c0c0\">uid=XmcumVqvKZd30002</text>\n",
-       "<text text-anchor=\"start\" x=\"811.6265\" y=\"-249\" font-family=\"Monospace\" font-size=\"10.00\" fill=\"#c0c0c0\">type=notebook, user=mkeller7</text>\n",
-       "<text text-anchor=\"start\" x=\"810.6499\" y=\"-239\" font-family=\"Monospace\" font-size=\"10.00\" fill=\"#c0c0c0\">run=2024&#45;12&#45;04 16:00:56 UTC</text>\n",
+       "<title>run_wW6GOHDq44lbrdKi08cr</title>\n",
+       "<path fill=\"#dcdcdc\" stroke=\"#065f46\" d=\"M1039.3699,-280C1039.3699,-280 910.4094,-280 910.4094,-280 904.4094,-280 898.4094,-274 898.4094,-268 898.4094,-268 898.4094,-244 898.4094,-244 898.4094,-238 904.4094,-232 910.4094,-232 910.4094,-232 1039.3699,-232 1039.3699,-232 1045.3699,-232 1051.3699,-238 1051.3699,-244 1051.3699,-244 1051.3699,-268 1051.3699,-268 1051.3699,-274 1045.3699,-280 1039.3699,-280\"/>\n",
+       "<text text-anchor=\"start\" x=\"948.1919\" y=\"-269\" font-family=\"Helvetica,sans-Serif\" font-size=\"10.00\" fill=\"#000000\">📔 Vitessce</text>\n",
+       "<text text-anchor=\"start\" x=\"918.6104\" y=\"-259\" font-family=\"Monospace\" font-size=\"10.00\" fill=\"#c0c0c0\">uid=BZhZQ6uIbkWv0000</text>\n",
+       "<text text-anchor=\"start\" x=\"907.6265\" y=\"-249\" font-family=\"Monospace\" font-size=\"10.00\" fill=\"#c0c0c0\">type=notebook, user=mkeller7</text>\n",
+       "<text text-anchor=\"start\" x=\"906.6499\" y=\"-239\" font-family=\"Monospace\" font-size=\"10.00\" fill=\"#c0c0c0\">run=2024&#45;12&#45;04 16:10:55 UTC</text>\n",
        "</g>\n",
-       "<!-- run_xt2ErUgo7KKqUOOAnVad&#45;&gt;artifact_0I5aMNdh2UrECtFX0000 -->\n",
-       "<g id=\"edge5\" class=\"edge\">\n",
-       "<title>run_xt2ErUgo7KKqUOOAnVad&#45;&gt;artifact_0I5aMNdh2UrECtFX0000</title>\n",
-       "<path fill=\"none\" stroke=\"#696969\" d=\"M802.42,-250.6543C680.4368,-241.7467 434.3971,-222.2233 226.8896,-196 225.5837,-195.835 224.27,-195.6664 222.9498,-195.4947\"/>\n",
-       "<polygon fill=\"#696969\" stroke=\"#696969\" points=\"223.0139,-193.738 217.8275,-194.8169 222.5547,-197.2078 223.0139,-193.738\"/>\n",
+       "<!-- run_wW6GOHDq44lbrdKi08cr&#45;&gt;artifact_0I5aMNdh2UrECtFX0000 -->\n",
+       "<g id=\"edge7\" class=\"edge\">\n",
+       "<title>run_wW6GOHDq44lbrdKi08cr&#45;&gt;artifact_0I5aMNdh2UrECtFX0000</title>\n",
+       "<path fill=\"none\" stroke=\"#696969\" d=\"M898.5047,-251.8865C762.9385,-244.1373 471.511,-225.4577 226.8896,-196 225.5828,-195.8426 224.2682,-195.6814 222.9471,-195.5166\"/>\n",
+       "<polygon fill=\"#696969\" stroke=\"#696969\" points=\"223.0029,-193.7596 217.8218,-194.8637 222.5605,-197.2315 223.0029,-193.7596\"/>\n",
        "</g>\n",
-       "<!-- run_xt2ErUgo7KKqUOOAnVad&#45;&gt;artifact_CMBUzbNNCEDGCKcQ0000 -->\n",
-       "<g id=\"edge6\" class=\"edge\">\n",
-       "<title>run_xt2ErUgo7KKqUOOAnVad&#45;&gt;artifact_CMBUzbNNCEDGCKcQ0000</title>\n",
-       "<path fill=\"none\" stroke=\"#696969\" d=\"M802.3324,-246.2445C715.529,-234.9909 569.8302,-215.5196 444.8896,-196 443.6027,-195.7989 442.3074,-195.5952 441.0051,-195.389\"/>\n",
-       "<polygon fill=\"#696969\" stroke=\"#696969\" points=\"441.1638,-193.6423 435.9505,-194.5826 440.6123,-197.0986 441.1638,-193.6423\"/>\n",
-       "</g>\n",
-       "<!-- artifact_nelDyBfwvEIIAKcC0000 -->\n",
-       "<g id=\"node6\" class=\"node\">\n",
-       "<title>artifact_nelDyBfwvEIIAKcC0000</title>\n",
-       "<path fill=\"#f0fff0\" stroke=\"#065f46\" d=\"M599.6593,-196C599.6593,-196 466.1199,-196 466.1199,-196 460.1199,-196 454.1199,-190 454.1199,-184 454.1199,-184 454.1199,-170 454.1199,-170 454.1199,-164 460.1199,-158 466.1199,-158 466.1199,-158 599.6593,-158 599.6593,-158 605.6593,-158 611.6593,-164 611.6593,-170 611.6593,-170 611.6593,-184 611.6593,-184 611.6593,-190 605.6593,-196 599.6593,-196\"/>\n",
-       "<text text-anchor=\"start\" x=\"462.0049\" y=\"-185\" font-family=\"Helvetica,sans-Serif\" font-size=\"10.00\" fill=\"#000000\">📄 Visium SpatialData Example</text>\n",
-       "<text text-anchor=\"start\" x=\"469.6621\" y=\"-175\" font-family=\"Monospace\" font-size=\"10.00\" fill=\"#c0c0c0\">uid=nelDyBfwvEIIAKcC0000</text>\n",
-       "<text text-anchor=\"start\" x=\"508.2998\" y=\"-165\" font-family=\"Monospace\" font-size=\"10.00\" fill=\"#c0c0c0\">suffix=.zarr</text>\n",
-       "</g>\n",
-       "<!-- run_xt2ErUgo7KKqUOOAnVad&#45;&gt;artifact_nelDyBfwvEIIAKcC0000 -->\n",
-       "<g id=\"edge4\" class=\"edge\">\n",
-       "<title>run_xt2ErUgo7KKqUOOAnVad&#45;&gt;artifact_nelDyBfwvEIIAKcC0000</title>\n",
-       "<path fill=\"none\" stroke=\"#696969\" d=\"M802.5301,-238.5653C747.5704,-226.0167 673.4515,-209.0936 616.8314,-196.1659\"/>\n",
-       "<polygon fill=\"#696969\" stroke=\"#696969\" points=\"617.0178,-194.4135 611.7537,-195.0065 616.2387,-197.8257 617.0178,-194.4135\"/>\n",
+       "<!-- run_wW6GOHDq44lbrdKi08cr&#45;&gt;artifact_CMBUzbNNCEDGCKcQ0000 -->\n",
+       "<g id=\"edge8\" class=\"edge\">\n",
+       "<title>run_wW6GOHDq44lbrdKi08cr&#45;&gt;artifact_CMBUzbNNCEDGCKcQ0000</title>\n",
+       "<path fill=\"none\" stroke=\"#696969\" d=\"M898.3476,-248.7865C795.1452,-238.7292 605.7547,-219.1048 444.8896,-196 443.6003,-195.8148 442.3027,-195.6261 440.9983,-195.4342\"/>\n",
+       "<polygon fill=\"#696969\" stroke=\"#696969\" points=\"441.1396,-193.686 435.9361,-194.6787 440.623,-197.1476 441.1396,-193.686\"/>\n",
        "</g>\n",
        "<!-- artifact_1g3a41z0hggWNBrk0000 -->\n",
-       "<g id=\"node7\" class=\"node\">\n",
+       "<g id=\"node6\" class=\"node\">\n",
        "<title>artifact_1g3a41z0hggWNBrk0000</title>\n",
-       "<path fill=\"#f0fff0\" stroke=\"#065f46\" d=\"M829.7852,-196C829.7852,-196 641.9941,-196 641.9941,-196 635.9941,-196 629.9941,-190 629.9941,-184 629.9941,-184 629.9941,-170 629.9941,-170 629.9941,-164 635.9941,-158 641.9941,-158 641.9941,-158 829.7852,-158 829.7852,-158 835.7852,-158 841.7852,-164 841.7852,-170 841.7852,-170 841.7852,-184 841.7852,-184 841.7852,-190 835.7852,-196 829.7852,-196\"/>\n",
-       "<text text-anchor=\"start\" x=\"637.9419\" y=\"-185\" font-family=\"Helvetica,sans-Serif\" font-size=\"10.00\" fill=\"#000000\">📄 Habib et al., 2017 Nature Methods, h5ad</text>\n",
-       "<text text-anchor=\"start\" x=\"669.0366\" y=\"-175\" font-family=\"Monospace\" font-size=\"10.00\" fill=\"#c0c0c0\">uid=1g3a41z0hggWNBrk0000</text>\n",
-       "<text text-anchor=\"start\" x=\"708.7876\" y=\"-165\" font-family=\"Monospace\" font-size=\"10.00\" fill=\"#c0c0c0\">suffix=.h5ad</text>\n",
+       "<path fill=\"#f0fff0\" stroke=\"#065f46\" d=\"M653.7852,-196C653.7852,-196 465.9941,-196 465.9941,-196 459.9941,-196 453.9941,-190 453.9941,-184 453.9941,-184 453.9941,-170 453.9941,-170 453.9941,-164 459.9941,-158 465.9941,-158 465.9941,-158 653.7852,-158 653.7852,-158 659.7852,-158 665.7852,-164 665.7852,-170 665.7852,-170 665.7852,-184 665.7852,-184 665.7852,-190 659.7852,-196 653.7852,-196\"/>\n",
+       "<text text-anchor=\"start\" x=\"461.9419\" y=\"-185\" font-family=\"Helvetica,sans-Serif\" font-size=\"10.00\" fill=\"#000000\">📄 Habib et al., 2017 Nature Methods, h5ad</text>\n",
+       "<text text-anchor=\"start\" x=\"493.0366\" y=\"-175\" font-family=\"Monospace\" font-size=\"10.00\" fill=\"#c0c0c0\">uid=1g3a41z0hggWNBrk0000</text>\n",
+       "<text text-anchor=\"start\" x=\"532.7876\" y=\"-165\" font-family=\"Monospace\" font-size=\"10.00\" fill=\"#c0c0c0\">suffix=.h5ad</text>\n",
        "</g>\n",
-       "<!-- run_xt2ErUgo7KKqUOOAnVad&#45;&gt;artifact_1g3a41z0hggWNBrk0000 -->\n",
-       "<g id=\"edge7\" class=\"edge\">\n",
-       "<title>run_xt2ErUgo7KKqUOOAnVad&#45;&gt;artifact_1g3a41z0hggWNBrk0000</title>\n",
-       "<path fill=\"none\" stroke=\"#696969\" d=\"M835.2079,-231.8681C816.1267,-221.3267 793.9139,-209.0553 775.3397,-198.7941\"/>\n",
-       "<polygon fill=\"#696969\" stroke=\"#696969\" points=\"775.9228,-197.1169 770.6999,-196.2309 774.2303,-200.1805 775.9228,-197.1169\"/>\n",
+       "<!-- run_wW6GOHDq44lbrdKi08cr&#45;&gt;artifact_1g3a41z0hggWNBrk0000 -->\n",
+       "<g id=\"edge4\" class=\"edge\">\n",
+       "<title>run_wW6GOHDq44lbrdKi08cr&#45;&gt;artifact_1g3a41z0hggWNBrk0000</title>\n",
+       "<path fill=\"none\" stroke=\"#696969\" d=\"M898.2886,-241.4181C832.7621,-228.9444 737.7998,-210.8672 665.1394,-197.0355\"/>\n",
+       "<polygon fill=\"#696969\" stroke=\"#696969\" points=\"665.1862,-195.263 659.9471,-196.0471 664.5316,-198.7013 665.1862,-195.263\"/>\n",
        "</g>\n",
        "<!-- artifact_O7CTVi6XjnfsceQ20000 -->\n",
-       "<g id=\"node8\" class=\"node\">\n",
+       "<g id=\"node7\" class=\"node\">\n",
        "<title>artifact_O7CTVi6XjnfsceQ20000</title>\n",
-       "<path fill=\"#f0fff0\" stroke=\"#065f46\" d=\"M1172.088,-196C1172.088,-196 871.6913,-196 871.6913,-196 865.6913,-196 859.6913,-190 859.6913,-184 859.6913,-184 859.6913,-170 859.6913,-170 859.6913,-164 865.6913,-158 871.6913,-158 871.6913,-158 1172.088,-158 1172.088,-158 1178.088,-158 1184.088,-164 1184.088,-170 1184.088,-170 1184.088,-184 1184.088,-184 1184.088,-190 1178.088,-196 1172.088,-196\"/>\n",
-       "<text text-anchor=\"start\" x=\"867.5405\" y=\"-185\" font-family=\"Helvetica,sans-Serif\" font-size=\"10.00\" fill=\"#000000\">📄 Reference JSON for H5AD file, Habib et al., 2017 Nature Methods</text>\n",
-       "<text text-anchor=\"start\" x=\"957.6343\" y=\"-175\" font-family=\"Monospace\" font-size=\"10.00\" fill=\"#c0c0c0\">uid=O7CTVi6XjnfsceQ20000</text>\n",
-       "<text text-anchor=\"start\" x=\"996.7383\" y=\"-165\" font-family=\"Monospace\" font-size=\"10.00\" fill=\"#c0c0c0\">suffix=.json</text>\n",
+       "<path fill=\"#f0fff0\" stroke=\"#065f46\" d=\"M996.088,-196C996.088,-196 695.6913,-196 695.6913,-196 689.6913,-196 683.6913,-190 683.6913,-184 683.6913,-184 683.6913,-170 683.6913,-170 683.6913,-164 689.6913,-158 695.6913,-158 695.6913,-158 996.088,-158 996.088,-158 1002.088,-158 1008.088,-164 1008.088,-170 1008.088,-170 1008.088,-184 1008.088,-184 1008.088,-190 1002.088,-196 996.088,-196\"/>\n",
+       "<text text-anchor=\"start\" x=\"691.5405\" y=\"-185\" font-family=\"Helvetica,sans-Serif\" font-size=\"10.00\" fill=\"#000000\">📄 Reference JSON for H5AD file, Habib et al., 2017 Nature Methods</text>\n",
+       "<text text-anchor=\"start\" x=\"781.6343\" y=\"-175\" font-family=\"Monospace\" font-size=\"10.00\" fill=\"#c0c0c0\">uid=O7CTVi6XjnfsceQ20000</text>\n",
+       "<text text-anchor=\"start\" x=\"820.7383\" y=\"-165\" font-family=\"Monospace\" font-size=\"10.00\" fill=\"#c0c0c0\">suffix=.json</text>\n",
        "</g>\n",
-       "<!-- run_xt2ErUgo7KKqUOOAnVad&#45;&gt;artifact_O7CTVi6XjnfsceQ20000 -->\n",
-       "<g id=\"edge8\" class=\"edge\">\n",
-       "<title>run_xt2ErUgo7KKqUOOAnVad&#45;&gt;artifact_O7CTVi6XjnfsceQ20000</title>\n",
-       "<path fill=\"none\" stroke=\"#696969\" d=\"M922.5714,-231.8681C941.6526,-221.3267 963.8654,-209.0553 982.4396,-198.7941\"/>\n",
-       "<polygon fill=\"#696969\" stroke=\"#696969\" points=\"983.549,-200.1805 987.0794,-196.2309 981.8565,-197.1169 983.549,-200.1805\"/>\n",
+       "<!-- run_wW6GOHDq44lbrdKi08cr&#45;&gt;artifact_O7CTVi6XjnfsceQ20000 -->\n",
+       "<g id=\"edge5\" class=\"edge\">\n",
+       "<title>run_wW6GOHDq44lbrdKi08cr&#45;&gt;artifact_O7CTVi6XjnfsceQ20000</title>\n",
+       "<path fill=\"none\" stroke=\"#696969\" d=\"M935.4845,-231.8681C918.4172,-221.4161 898.5726,-209.2632 881.9041,-199.0554\"/>\n",
+       "<polygon fill=\"#696969\" stroke=\"#696969\" points=\"882.4699,-197.3498 877.2919,-196.2309 880.642,-200.3346 882.4699,-197.3498\"/>\n",
+       "</g>\n",
+       "<!-- artifact_nelDyBfwvEIIAKcC0000 -->\n",
+       "<g id=\"node8\" class=\"node\">\n",
+       "<title>artifact_nelDyBfwvEIIAKcC0000</title>\n",
+       "<path fill=\"#f0fff0\" stroke=\"#065f46\" d=\"M1171.6593,-196C1171.6593,-196 1038.1199,-196 1038.1199,-196 1032.1199,-196 1026.1199,-190 1026.1199,-184 1026.1199,-184 1026.1199,-170 1026.1199,-170 1026.1199,-164 1032.1199,-158 1038.1199,-158 1038.1199,-158 1171.6593,-158 1171.6593,-158 1177.6593,-158 1183.6593,-164 1183.6593,-170 1183.6593,-170 1183.6593,-184 1183.6593,-184 1183.6593,-190 1177.6593,-196 1171.6593,-196\"/>\n",
+       "<text text-anchor=\"start\" x=\"1034.0049\" y=\"-185\" font-family=\"Helvetica,sans-Serif\" font-size=\"10.00\" fill=\"#000000\">📄 Visium SpatialData Example</text>\n",
+       "<text text-anchor=\"start\" x=\"1041.6621\" y=\"-175\" font-family=\"Monospace\" font-size=\"10.00\" fill=\"#c0c0c0\">uid=nelDyBfwvEIIAKcC0000</text>\n",
+       "<text text-anchor=\"start\" x=\"1080.2998\" y=\"-165\" font-family=\"Monospace\" font-size=\"10.00\" fill=\"#c0c0c0\">suffix=.zarr</text>\n",
+       "</g>\n",
+       "<!-- run_wW6GOHDq44lbrdKi08cr&#45;&gt;artifact_nelDyBfwvEIIAKcC0000 -->\n",
+       "<g id=\"edge6\" class=\"edge\">\n",
+       "<title>run_wW6GOHDq44lbrdKi08cr&#45;&gt;artifact_nelDyBfwvEIIAKcC0000</title>\n",
+       "<path fill=\"none\" stroke=\"#696969\" d=\"M1014.6003,-231.8681C1031.7999,-221.4161 1051.7983,-209.2632 1068.596,-199.0554\"/>\n",
+       "<polygon fill=\"#696969\" stroke=\"#696969\" points=\"1069.8798,-200.323 1073.2439,-196.2309 1068.0622,-197.332 1069.8798,-200.323\"/>\n",
        "</g>\n",
        "<!-- artifact_kWwG45Hr26KZUW3g0004 -->\n",
        "<g id=\"node9\" class=\"node\">\n",
        "<title>artifact_kWwG45Hr26KZUW3g0004</title>\n",
-       "<path fill=\"#f0fff0\" stroke=\"#065f46\" d=\"M1397.2608,-196C1397.2608,-196 1214.5185,-196 1214.5185,-196 1208.5185,-196 1202.5185,-190 1202.5185,-184 1202.5185,-184 1202.5185,-170 1202.5185,-170 1202.5185,-164 1208.5185,-158 1214.5185,-158 1214.5185,-158 1397.2608,-158 1397.2608,-158 1403.2608,-158 1409.2608,-164 1409.2608,-170 1409.2608,-170 1409.2608,-184 1409.2608,-184 1409.2608,-190 1403.2608,-196 1397.2608,-196\"/>\n",
-       "<text text-anchor=\"start\" x=\"1210.4541\" y=\"-185\" font-family=\"Helvetica,sans-Serif\" font-size=\"10.00\" fill=\"#000000\">📄 Habib et al., 2017 Nature Methods, zarr</text>\n",
-       "<text text-anchor=\"start\" x=\"1233.7754\" y=\"-175\" font-family=\"Monospace\" font-size=\"10.00\" fill=\"#c0c0c0\">uid=kWwG45Hr26KZUW3g0004</text>\n",
-       "<text text-anchor=\"start\" x=\"1261.8369\" y=\"-165\" font-family=\"Monospace\" font-size=\"10.00\" fill=\"#c0c0c0\">suffix=.anndata.zarr</text>\n",
+       "<path fill=\"#f0fff0\" stroke=\"#065f46\" d=\"M1396.2608,-196C1396.2608,-196 1213.5185,-196 1213.5185,-196 1207.5185,-196 1201.5185,-190 1201.5185,-184 1201.5185,-184 1201.5185,-170 1201.5185,-170 1201.5185,-164 1207.5185,-158 1213.5185,-158 1213.5185,-158 1396.2608,-158 1396.2608,-158 1402.2608,-158 1408.2608,-164 1408.2608,-170 1408.2608,-170 1408.2608,-184 1408.2608,-184 1408.2608,-190 1402.2608,-196 1396.2608,-196\"/>\n",
+       "<text text-anchor=\"start\" x=\"1209.4541\" y=\"-185\" font-family=\"Helvetica,sans-Serif\" font-size=\"10.00\" fill=\"#000000\">📄 Habib et al., 2017 Nature Methods, zarr</text>\n",
+       "<text text-anchor=\"start\" x=\"1232.7754\" y=\"-175\" font-family=\"Monospace\" font-size=\"10.00\" fill=\"#c0c0c0\">uid=kWwG45Hr26KZUW3g0004</text>\n",
+       "<text text-anchor=\"start\" x=\"1260.8369\" y=\"-165\" font-family=\"Monospace\" font-size=\"10.00\" fill=\"#c0c0c0\">suffix=.anndata.zarr</text>\n",
        "</g>\n",
-       "<!-- run_xt2ErUgo7KKqUOOAnVad&#45;&gt;artifact_kWwG45Hr26KZUW3g0004 -->\n",
+       "<!-- run_wW6GOHDq44lbrdKi08cr&#45;&gt;artifact_kWwG45Hr26KZUW3g0004 -->\n",
        "<g id=\"edge9\" class=\"edge\">\n",
-       "<title>run_xt2ErUgo7KKqUOOAnVad&#45;&gt;artifact_kWwG45Hr26KZUW3g0004</title>\n",
-       "<path fill=\"none\" stroke=\"#696969\" d=\"M955.2287,-241.8764C1022.8309,-229.3692 1122.2496,-210.9756 1197.9798,-196.9646\"/>\n",
-       "<polygon fill=\"#696969\" stroke=\"#696969\" points=\"1198.335,-198.6787 1202.9331,-196.0482 1197.6982,-195.2371 1198.335,-198.6787\"/>\n",
+       "<title>run_wW6GOHDq44lbrdKi08cr&#45;&gt;artifact_kWwG45Hr26KZUW3g0004</title>\n",
+       "<path fill=\"none\" stroke=\"#696969\" d=\"M1051.4277,-237.6772C1101.9673,-225.5784 1168.2277,-209.716 1220.3249,-197.2443\"/>\n",
+       "<polygon fill=\"#696969\" stroke=\"#696969\" points=\"1220.8662,-198.9142 1225.3214,-196.0482 1220.0513,-195.5104 1220.8662,-198.9142\"/>\n",
        "</g>\n",
        "<!-- collection_obXokdzOnSH2tytJ0000 -->\n",
        "<g id=\"node10\" class=\"node\">\n",
        "<title>collection_obXokdzOnSH2tytJ0000</title>\n",
-       "<path fill=\"#f0fff0\" stroke=\"#065f46\" d=\"M1590.8379,-196C1590.8379,-196 1438.9414,-196 1438.9414,-196 1432.9414,-196 1426.9414,-190 1426.9414,-184 1426.9414,-184 1426.9414,-170 1426.9414,-170 1426.9414,-164 1432.9414,-158 1438.9414,-158 1438.9414,-158 1590.8379,-158 1590.8379,-158 1596.8379,-158 1602.8379,-164 1602.8379,-170 1602.8379,-170 1602.8379,-184 1602.8379,-184 1602.8379,-190 1596.8379,-196 1590.8379,-196\"/>\n",
-       "<text text-anchor=\"start\" x=\"1434.9155\" y=\"-185\" font-family=\"Helvetica,sans-Serif\" font-size=\"10.00\" fill=\"#000000\">🍱 View Habib17 (h5ad) in Vitessce</text>\n",
-       "<text text-anchor=\"start\" x=\"1450.5415\" y=\"-175\" font-family=\"Monospace\" font-size=\"10.00\" fill=\"#c0c0c0\">uid=obXokdzOnSH2tytJ0000</text>\n",
-       "<text text-anchor=\"start\" x=\"1483.8984\" y=\"-165\" font-family=\"Monospace\" font-size=\"10.00\" fill=\"#c0c0c0\">version=None</text>\n",
+       "<path fill=\"#f0fff0\" stroke=\"#065f46\" d=\"M1589.8379,-196C1589.8379,-196 1437.9414,-196 1437.9414,-196 1431.9414,-196 1425.9414,-190 1425.9414,-184 1425.9414,-184 1425.9414,-170 1425.9414,-170 1425.9414,-164 1431.9414,-158 1437.9414,-158 1437.9414,-158 1589.8379,-158 1589.8379,-158 1595.8379,-158 1601.8379,-164 1601.8379,-170 1601.8379,-170 1601.8379,-184 1601.8379,-184 1601.8379,-190 1595.8379,-196 1589.8379,-196\"/>\n",
+       "<text text-anchor=\"start\" x=\"1433.9155\" y=\"-185\" font-family=\"Helvetica,sans-Serif\" font-size=\"10.00\" fill=\"#000000\">🍱 View Habib17 (h5ad) in Vitessce</text>\n",
+       "<text text-anchor=\"start\" x=\"1449.5415\" y=\"-175\" font-family=\"Monospace\" font-size=\"10.00\" fill=\"#c0c0c0\">uid=obXokdzOnSH2tytJ0000</text>\n",
+       "<text text-anchor=\"start\" x=\"1482.8984\" y=\"-165\" font-family=\"Monospace\" font-size=\"10.00\" fill=\"#c0c0c0\">version=None</text>\n",
        "</g>\n",
-       "<!-- run_xt2ErUgo7KKqUOOAnVad&#45;&gt;collection_obXokdzOnSH2tytJ0000 -->\n",
+       "<!-- run_wW6GOHDq44lbrdKi08cr&#45;&gt;collection_obXokdzOnSH2tytJ0000 -->\n",
        "<g id=\"edge10\" class=\"edge\">\n",
-       "<title>run_xt2ErUgo7KKqUOOAnVad&#45;&gt;collection_obXokdzOnSH2tytJ0000</title>\n",
-       "<path fill=\"none\" stroke=\"#696969\" d=\"M955.4681,-249.4818C1060.2052,-240.11 1253.8595,-221.1506 1417.8896,-196 1419.1883,-195.8009 1420.496,-195.5967 1421.8112,-195.3879\"/>\n",
-       "<polygon fill=\"#696969\" stroke=\"#696969\" points=\"1422.261,-197.0879 1426.9167,-194.5607 1421.7012,-193.6329 1422.261,-197.0879\"/>\n",
+       "<title>run_wW6GOHDq44lbrdKi08cr&#45;&gt;collection_obXokdzOnSH2tytJ0000</title>\n",
+       "<path fill=\"none\" stroke=\"#696969\" d=\"M1051.3531,-246.9988C1139.6368,-236.2868 1289.113,-217.1682 1416.8896,-196 1418.1858,-195.7853 1419.4912,-195.5664 1420.8041,-195.3438\"/>\n",
+       "<polygon fill=\"#696969\" stroke=\"#696969\" points=\"1421.2706,-197.0394 1425.9019,-194.4678 1420.6777,-193.5899 1421.2706,-197.0394\"/>\n",
        "</g>\n",
        "<!-- collection_HqfzZmkfYOy20ZNN0000 -->\n",
        "<g id=\"node11\" class=\"node\">\n",
        "<title>collection_HqfzZmkfYOy20ZNN0000</title>\n",
-       "<path fill=\"#f0fff0\" stroke=\"#065f46\" d=\"M1885.2336,-196C1885.2336,-196 1632.5457,-196 1632.5457,-196 1626.5457,-196 1620.5457,-190 1620.5457,-184 1620.5457,-184 1620.5457,-170 1620.5457,-170 1620.5457,-164 1626.5457,-158 1632.5457,-158 1632.5457,-158 1885.2336,-158 1885.2336,-158 1891.2336,-158 1897.2336,-164 1897.2336,-170 1897.2336,-170 1897.2336,-184 1897.2336,-184 1897.2336,-190 1891.2336,-196 1885.2336,-196\"/>\n",
-       "<text text-anchor=\"start\" x=\"1628.7178\" y=\"-185\" font-family=\"Helvetica,sans-Serif\" font-size=\"10.00\" fill=\"#000000\">🍱 View PAS OME&#45;TIFF, Neumann et al., 2020 in Vitessce</text>\n",
-       "<text text-anchor=\"start\" x=\"1691.2236\" y=\"-175\" font-family=\"Monospace\" font-size=\"10.00\" fill=\"#c0c0c0\">uid=HqfzZmkfYOy20ZNN0000</text>\n",
-       "<text text-anchor=\"start\" x=\"1727.8984\" y=\"-165\" font-family=\"Monospace\" font-size=\"10.00\" fill=\"#c0c0c0\">version=None</text>\n",
+       "<path fill=\"#f0fff0\" stroke=\"#065f46\" d=\"M1884.2336,-196C1884.2336,-196 1631.5457,-196 1631.5457,-196 1625.5457,-196 1619.5457,-190 1619.5457,-184 1619.5457,-184 1619.5457,-170 1619.5457,-170 1619.5457,-164 1625.5457,-158 1631.5457,-158 1631.5457,-158 1884.2336,-158 1884.2336,-158 1890.2336,-158 1896.2336,-164 1896.2336,-170 1896.2336,-170 1896.2336,-184 1896.2336,-184 1896.2336,-190 1890.2336,-196 1884.2336,-196\"/>\n",
+       "<text text-anchor=\"start\" x=\"1627.7178\" y=\"-185\" font-family=\"Helvetica,sans-Serif\" font-size=\"10.00\" fill=\"#000000\">🍱 View PAS OME&#45;TIFF, Neumann et al., 2020 in Vitessce</text>\n",
+       "<text text-anchor=\"start\" x=\"1690.2236\" y=\"-175\" font-family=\"Monospace\" font-size=\"10.00\" fill=\"#c0c0c0\">uid=HqfzZmkfYOy20ZNN0000</text>\n",
+       "<text text-anchor=\"start\" x=\"1726.8984\" y=\"-165\" font-family=\"Monospace\" font-size=\"10.00\" fill=\"#c0c0c0\">version=None</text>\n",
        "</g>\n",
-       "<!-- run_xt2ErUgo7KKqUOOAnVad&#45;&gt;collection_HqfzZmkfYOy20ZNN0000 -->\n",
+       "<!-- run_wW6GOHDq44lbrdKi08cr&#45;&gt;collection_HqfzZmkfYOy20ZNN0000 -->\n",
        "<g id=\"edge11\" class=\"edge\">\n",
-       "<title>run_xt2ErUgo7KKqUOOAnVad&#45;&gt;collection_HqfzZmkfYOy20ZNN0000</title>\n",
-       "<path fill=\"none\" stroke=\"#696969\" d=\"M955.2406,-250.934C1088.6279,-241.8192 1372.695,-221.2338 1611.8896,-196 1613.0333,-195.8794 1614.1817,-195.7571 1615.3345,-195.6334\"/>\n",
-       "<polygon fill=\"#696969\" stroke=\"#696969\" points=\"1615.6336,-197.3613 1620.4155,-195.0818 1615.2558,-193.8818 1615.6336,-197.3613\"/>\n",
+       "<title>run_wW6GOHDq44lbrdKi08cr&#45;&gt;collection_HqfzZmkfYOy20ZNN0000</title>\n",
+       "<path fill=\"none\" stroke=\"#696969\" d=\"M1051.3387,-249.6451C1170.8584,-239.5166 1409.1858,-218.5428 1610.8896,-196 1612.0325,-195.8723 1613.1802,-195.7432 1614.3323,-195.6129\"/>\n",
+       "<polygon fill=\"#696969\" stroke=\"#696969\" points=\"1614.6407,-197.3392 1619.4103,-195.0339 1614.2442,-193.8617 1614.6407,-197.3392\"/>\n",
        "</g>\n",
        "</g>\n",
        "</svg>\n"
@@ -1545,7 +1951,13 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "editable": true,
+    "slideshow": {
+     "slide_type": ""
+    },
+    "tags": []
+   },
    "source": [
     ":::{note}\n",
     "\n",
@@ -1559,22 +1971,40 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "editable": true,
+    "slideshow": {
+     "slide_type": ""
+    },
+    "tags": []
+   },
    "source": [
     "## Visualize an image (OME-Zarr format)"
    ]
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "editable": true,
+    "slideshow": {
+     "slide_type": ""
+    },
+    "tags": []
+   },
    "source": [
     "Retrieve an OME-Zarr (also known as OME-NGFF) formatted image. We could download an unzip such an image, but in downloading the SpatialData object above, we already have access to a valid OME-Zarr image locally."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 40,
-   "metadata": {},
+   "execution_count": 32,
+   "metadata": {
+    "editable": true,
+    "slideshow": {
+     "slide_type": ""
+    },
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "ome_zarr_filepath = Path(sdata_zarr_filepath) / \"images\" / \"CytAssist_FFPE_Human_Breast_Cancer_full_image\""
@@ -1582,37 +2012,55 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "editable": true,
+    "slideshow": {
+     "slide_type": ""
+    },
+    "tags": []
+   },
    "source": [
     "### Save the dataset"
    ]
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "editable": true,
+    "slideshow": {
+     "slide_type": ""
+    },
+    "tags": []
+   },
    "source": [
     "Save the `.ome.zarr` DirectoryStore as a LaminDB Artifact."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 41,
-   "metadata": {},
+   "execution_count": 33,
+   "metadata": {
+    "editable": true,
+    "slideshow": {
+     "slide_type": ""
+    },
+    "tags": []
+   },
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[92m→\u001b[0m returning existing artifact with same hash: Artifact(uid='toCvpsqAiH3XcAvT0000', is_latest=True, key='vitessce_examples/visium.ome.zarr', description='Visium OME-Zarr Example', suffix='', type='dataset', size=1400251840, hash='UtsNOkk05EFL34hgUabEwg', n_objects=8809, _hash_type='md5-d', visibility=1, _key_is_virtual=True, storage_id=1, transform_id=16, run_id=73, created_by_id=2, created_at=2024-12-04 14:38:29 UTC)\n"
+      "\u001b[92m→\u001b[0m returning existing artifact with same hash: Artifact(uid='toCvpsqAiH3XcAvT0000', is_latest=True, key='vitessce_examples/visium.ome.zarr', description='Visium OME-Zarr Example', suffix='', type='dataset', size=1400251840, hash='UtsNOkk05EFL34hgUabEwg', n_objects=8809, _hash_type='md5-d', visibility=1, _key_is_virtual=True, storage_id=1, transform_id=17, run_id=79, created_by_id=2, created_at=2024-12-04 14:38:29 UTC)\n"
      ]
     },
     {
      "data": {
       "text/plain": [
-       "Artifact(uid='toCvpsqAiH3XcAvT0000', is_latest=True, key='vitessce_examples/visium.ome.zarr', description='Visium OME-Zarr Example', suffix='', type='dataset', size=1400251840, hash='UtsNOkk05EFL34hgUabEwg', n_objects=8809, _hash_type='md5-d', visibility=1, _key_is_virtual=True, storage_id=1, transform_id=17, run_id=79, created_by_id=2, created_at=2024-12-04 14:38:29 UTC)"
+       "Artifact(uid='toCvpsqAiH3XcAvT0000', is_latest=True, key='vitessce_examples/visium.ome.zarr', description='Visium OME-Zarr Example', suffix='', type='dataset', size=1400251840, hash='UtsNOkk05EFL34hgUabEwg', n_objects=8809, _hash_type='md5-d', visibility=1, _key_is_virtual=True, storage_id=1, transform_id=18, run_id=85, created_by_id=2, created_at=2024-12-04 14:38:29 UTC)"
       ]
      },
-     "execution_count": 41,
+     "execution_count": 33,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1629,14 +2077,26 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "editable": true,
+    "slideshow": {
+     "slide_type": ""
+    },
+    "tags": []
+   },
    "source": [
     "### Save a VitessceConfig object"
    ]
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "editable": true,
+    "slideshow": {
+     "slide_type": ""
+    },
+    "tags": []
+   },
    "source": [
     "You can create a dashboard for one or several datasets by using Vitessce's component API.\n",
     "Here, we use the [ImageOmeZarrWrapper](https://python-docs.vitessce.io/api_data.html#vitessce.wrappers.ImageOmeZarrWrapper) class to specify an OME-Zarr file to load for visualization."
@@ -1644,8 +2104,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 42,
-   "metadata": {},
+   "execution_count": 34,
+   "metadata": {
+    "editable": true,
+    "slideshow": {
+     "slide_type": ""
+    },
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "vc = vit.VitessceConfig(\n",
@@ -1670,15 +2136,25 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "editable": true,
+    "slideshow": {
+     "slide_type": ""
+    },
+    "tags": []
+   },
    "source": [
     "Save the `VitessceConfig` object."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 43,
+   "execution_count": 35,
    "metadata": {
+    "editable": true,
+    "slideshow": {
+     "slide_type": ""
+    },
     "tags": [
      "hide-output"
     ]
@@ -1689,8 +2165,8 @@
      "output_type": "stream",
      "text": [
       "\u001b[92m→\u001b[0m VitessceConfig references these artifacts:\n",
-      "Artifact(uid='toCvpsqAiH3XcAvT0000', is_latest=True, key='vitessce_examples/visium.ome.zarr', description='Visium OME-Zarr Example', suffix='', type='dataset', size=1400251840, hash='UtsNOkk05EFL34hgUabEwg', n_objects=8809, _hash_type='md5-d', visibility=1, _key_is_virtual=True, storage_id=1, transform_id=17, run_id=79, created_by_id=2, created_at=2024-12-04 14:38:29 UTC)\n",
-      "\u001b[92m→\u001b[0m returning existing artifact with same hash: Artifact(uid='cjvX6EFrdSwsxOQl0000', is_latest=True, description='View Visium OME-Zarr Example in Vitessce', suffix='.vitessce.json', size=1240, hash='PiQa8hZ7nphs4FoTdhOwxg', _hash_type='md5', visibility=1, _key_is_virtual=True, storage_id=1, transform_id=15, run_id=78, created_by_id=2, created_at=2024-12-04 15:53:20 UTC)\n",
+      "Artifact(uid='toCvpsqAiH3XcAvT0000', is_latest=True, key='vitessce_examples/visium.ome.zarr', description='Visium OME-Zarr Example', suffix='', type='dataset', size=1400251840, hash='UtsNOkk05EFL34hgUabEwg', n_objects=8809, _hash_type='md5-d', visibility=1, _key_is_virtual=True, storage_id=1, transform_id=18, run_id=85, created_by_id=2, created_at=2024-12-04 14:38:29 UTC)\n",
+      "\u001b[92m→\u001b[0m returning existing artifact with same hash: Artifact(uid='cjvX6EFrdSwsxOQl0000', is_latest=True, description='View Visium OME-Zarr Example in Vitessce', suffix='.vitessce.json', size=1240, hash='PiQa8hZ7nphs4FoTdhOwxg', _hash_type='md5', visibility=1, _key_is_virtual=True, storage_id=1, transform_id=15, run_id=84, created_by_id=2, created_at=2024-12-04 15:53:20 UTC)\n",
       "\u001b[92m→\u001b[0m VitessceConfig: https://lamin.ai/vitessce/examples/artifact/cjvX6EFrdSwsxOQl0000\n",
       "\u001b[92m→\u001b[0m Dataset: https://lamin.ai/vitessce/examples/artifact/toCvpsqAiH3XcAvT0000\n"
      ]
@@ -1704,8 +2180,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 44,
-   "metadata": {},
+   "execution_count": 36,
+   "metadata": {
+    "editable": true,
+    "slideshow": {
+     "slide_type": ""
+    },
+    "tags": []
+   },
    "outputs": [
     {
      "data": {
@@ -1716,11 +2198,11 @@
        "<!-- Generated by graphviz version 2.40.1 (20161225.0304)\n",
        " -->\n",
        "<!-- Title: artifact_cjvX6EFrdSwsxOQl0000 Pages: 1 -->\n",
-       "<svg width=\"2111pt\" height=\"288pt\"\n",
-       " viewBox=\"0.00 0.00 2111.04 288.00\" xmlns=\"http://www.w3.org/2000/svg\" xmlns:xlink=\"http://www.w3.org/1999/xlink\">\n",
+       "<svg width=\"2110pt\" height=\"288pt\"\n",
+       " viewBox=\"0.00 0.00 2110.04 288.00\" xmlns=\"http://www.w3.org/2000/svg\" xmlns:xlink=\"http://www.w3.org/1999/xlink\">\n",
        "<g id=\"graph0\" class=\"graph\" transform=\"scale(1 1) rotate(0) translate(4 284)\">\n",
        "<title>artifact_cjvX6EFrdSwsxOQl0000</title>\n",
-       "<polygon fill=\"#ffffff\" stroke=\"transparent\" points=\"-4,4 -4,-284 2107.0435,-284 2107.0435,4 -4,4\"/>\n",
+       "<polygon fill=\"#ffffff\" stroke=\"transparent\" points=\"-4,4 -4,-284 2106.0435,-284 2106.0435,4 -4,4\"/>\n",
        "<!-- artifact_toCvpsqAiH3XcAvT0000 -->\n",
        "<g id=\"node1\" class=\"node\">\n",
        "<title>artifact_toCvpsqAiH3XcAvT0000</title>\n",
@@ -1729,18 +2211,18 @@
        "<text text-anchor=\"start\" x=\"48.3403\" y=\"-175\" font-family=\"Monospace\" font-size=\"10.00\" fill=\"#c0c0c0\">uid=toCvpsqAiH3XcAvT0000</text>\n",
        "<text text-anchor=\"start\" x=\"98.2817\" y=\"-165\" font-family=\"Monospace\" font-size=\"10.00\" fill=\"#c0c0c0\">suffix=</text>\n",
        "</g>\n",
-       "<!-- run_VtJZt0vnqrXHjGQU3Jdu -->\n",
+       "<!-- run_aMMKqF2TfoQCrTnnJhBJ -->\n",
        "<g id=\"node2\" class=\"node\">\n",
-       "<title>run_VtJZt0vnqrXHjGQU3Jdu</title>\n",
-       "<path fill=\"#dcdcdc\" stroke=\"#065f46\" d=\"M177.3518,-122C177.3518,-122 48.3913,-122 48.3913,-122 42.3913,-122 36.3913,-116 36.3913,-110 36.3913,-110 36.3913,-86 36.3913,-86 36.3913,-80 42.3913,-74 48.3913,-74 48.3913,-74 177.3518,-74 177.3518,-74 183.3518,-74 189.3518,-80 189.3518,-86 189.3518,-86 189.3518,-110 189.3518,-110 189.3518,-116 183.3518,-122 177.3518,-122\"/>\n",
+       "<title>run_aMMKqF2TfoQCrTnnJhBJ</title>\n",
+       "<path fill=\"#dcdcdc\" stroke=\"#065f46\" d=\"M176.614,-122C176.614,-122 49.1292,-122 49.1292,-122 43.1292,-122 37.1292,-116 37.1292,-110 37.1292,-110 37.1292,-86 37.1292,-86 37.1292,-80 43.1292,-74 49.1292,-74 49.1292,-74 176.614,-74 176.614,-74 182.614,-74 188.614,-80 188.614,-86 188.614,-86 188.614,-110 188.614,-110 188.614,-116 182.614,-122 176.614,-122\"/>\n",
        "<text text-anchor=\"start\" x=\"57.4556\" y=\"-111\" font-family=\"Helvetica,sans-Serif\" font-size=\"10.00\" fill=\"#000000\">🔧 save_vitessce_config</text>\n",
        "<text text-anchor=\"start\" x=\"58.897\" y=\"-101\" font-family=\"Monospace\" font-size=\"10.00\" fill=\"#c0c0c0\">uid=kup03MJBsIVa0002</text>\n",
        "<text text-anchor=\"start\" x=\"48.6699\" y=\"-91\" font-family=\"Monospace\" font-size=\"10.00\" fill=\"#c0c0c0\">type=function, user=mkeller7</text>\n",
-       "<text text-anchor=\"start\" x=\"44.6318\" y=\"-81\" font-family=\"Monospace\" font-size=\"10.00\" fill=\"#c0c0c0\">run=2024&#45;12&#45;04 16:01:44 UTC</text>\n",
+       "<text text-anchor=\"start\" x=\"45.0005\" y=\"-81\" font-family=\"Monospace\" font-size=\"10.00\" fill=\"#c0c0c0\">run=2024&#45;12&#45;04 16:11:51 UTC</text>\n",
        "</g>\n",
-       "<!-- artifact_toCvpsqAiH3XcAvT0000&#45;&gt;run_VtJZt0vnqrXHjGQU3Jdu -->\n",
+       "<!-- artifact_toCvpsqAiH3XcAvT0000&#45;&gt;run_aMMKqF2TfoQCrTnnJhBJ -->\n",
        "<g id=\"edge1\" class=\"edge\">\n",
-       "<title>artifact_toCvpsqAiH3XcAvT0000&#45;&gt;run_VtJZt0vnqrXHjGQU3Jdu</title>\n",
+       "<title>artifact_toCvpsqAiH3XcAvT0000&#45;&gt;run_aMMKqF2TfoQCrTnnJhBJ</title>\n",
        "<path fill=\"none\" stroke=\"#696969\" d=\"M112.8716,-157.8763C112.8716,-148.6991 112.8716,-137.5013 112.8716,-127.2829\"/>\n",
        "<polygon fill=\"#696969\" stroke=\"#696969\" points=\"114.6217,-127.0445 112.8716,-122.0445 111.1217,-127.0445 114.6217,-127.0445\"/>\n",
        "</g>\n",
@@ -1752,138 +2234,138 @@
        "<text text-anchor=\"start\" x=\"48.2598\" y=\"-17\" font-family=\"Monospace\" font-size=\"10.00\" fill=\"#c0c0c0\">uid=cjvX6EFrdSwsxOQl0000</text>\n",
        "<text text-anchor=\"start\" x=\"68.2695\" y=\"-7\" font-family=\"Monospace\" font-size=\"10.00\" fill=\"#c0c0c0\">suffix=.vitessce.json</text>\n",
        "</g>\n",
-       "<!-- run_VtJZt0vnqrXHjGQU3Jdu&#45;&gt;artifact_cjvX6EFrdSwsxOQl0000 -->\n",
+       "<!-- run_aMMKqF2TfoQCrTnnJhBJ&#45;&gt;artifact_cjvX6EFrdSwsxOQl0000 -->\n",
        "<g id=\"edge2\" class=\"edge\">\n",
-       "<title>run_VtJZt0vnqrXHjGQU3Jdu&#45;&gt;artifact_cjvX6EFrdSwsxOQl0000</title>\n",
+       "<title>run_aMMKqF2TfoQCrTnnJhBJ&#45;&gt;artifact_cjvX6EFrdSwsxOQl0000</title>\n",
        "<path fill=\"none\" stroke=\"#696969\" d=\"M112.8716,-73.8681C112.8716,-64.2201 112.8716,-53.1228 112.8716,-43.4439\"/>\n",
        "<polygon fill=\"#696969\" stroke=\"#696969\" points=\"114.6217,-43.2308 112.8716,-38.2309 111.1217,-43.2309 114.6217,-43.2308\"/>\n",
        "</g>\n",
-       "<!-- run_xt2ErUgo7KKqUOOAnVad -->\n",
+       "<!-- run_wW6GOHDq44lbrdKi08cr -->\n",
        "<g id=\"node4\" class=\"node\">\n",
-       "<title>run_xt2ErUgo7KKqUOOAnVad</title>\n",
-       "<path fill=\"#dcdcdc\" stroke=\"#065f46\" d=\"M1006.3518,-280C1006.3518,-280 877.3913,-280 877.3913,-280 871.3913,-280 865.3913,-274 865.3913,-268 865.3913,-268 865.3913,-244 865.3913,-244 865.3913,-238 871.3913,-232 877.3913,-232 877.3913,-232 1006.3518,-232 1006.3518,-232 1012.3518,-232 1018.3518,-238 1018.3518,-244 1018.3518,-244 1018.3518,-268 1018.3518,-268 1018.3518,-274 1012.3518,-280 1006.3518,-280\"/>\n",
-       "<text text-anchor=\"start\" x=\"915.1738\" y=\"-269\" font-family=\"Helvetica,sans-Serif\" font-size=\"10.00\" fill=\"#000000\">📔 Vitessce</text>\n",
-       "<text text-anchor=\"start\" x=\"883.644\" y=\"-259\" font-family=\"Monospace\" font-size=\"10.00\" fill=\"#c0c0c0\">uid=XmcumVqvKZd30002</text>\n",
-       "<text text-anchor=\"start\" x=\"874.6084\" y=\"-249\" font-family=\"Monospace\" font-size=\"10.00\" fill=\"#c0c0c0\">type=notebook, user=mkeller7</text>\n",
-       "<text text-anchor=\"start\" x=\"873.6318\" y=\"-239\" font-family=\"Monospace\" font-size=\"10.00\" fill=\"#c0c0c0\">run=2024&#45;12&#45;04 16:00:56 UTC</text>\n",
+       "<title>run_wW6GOHDq44lbrdKi08cr</title>\n",
+       "<path fill=\"#dcdcdc\" stroke=\"#065f46\" d=\"M1127.3518,-280C1127.3518,-280 998.3913,-280 998.3913,-280 992.3913,-280 986.3913,-274 986.3913,-268 986.3913,-268 986.3913,-244 986.3913,-244 986.3913,-238 992.3913,-232 998.3913,-232 998.3913,-232 1127.3518,-232 1127.3518,-232 1133.3518,-232 1139.3518,-238 1139.3518,-244 1139.3518,-244 1139.3518,-268 1139.3518,-268 1139.3518,-274 1133.3518,-280 1127.3518,-280\"/>\n",
+       "<text text-anchor=\"start\" x=\"1036.1738\" y=\"-269\" font-family=\"Helvetica,sans-Serif\" font-size=\"10.00\" fill=\"#000000\">📔 Vitessce</text>\n",
+       "<text text-anchor=\"start\" x=\"1006.5923\" y=\"-259\" font-family=\"Monospace\" font-size=\"10.00\" fill=\"#c0c0c0\">uid=BZhZQ6uIbkWv0000</text>\n",
+       "<text text-anchor=\"start\" x=\"995.6084\" y=\"-249\" font-family=\"Monospace\" font-size=\"10.00\" fill=\"#c0c0c0\">type=notebook, user=mkeller7</text>\n",
+       "<text text-anchor=\"start\" x=\"994.6318\" y=\"-239\" font-family=\"Monospace\" font-size=\"10.00\" fill=\"#c0c0c0\">run=2024&#45;12&#45;04 16:10:55 UTC</text>\n",
        "</g>\n",
-       "<!-- run_xt2ErUgo7KKqUOOAnVad&#45;&gt;artifact_toCvpsqAiH3XcAvT0000 -->\n",
-       "<g id=\"edge6\" class=\"edge\">\n",
-       "<title>run_xt2ErUgo7KKqUOOAnVad&#45;&gt;artifact_toCvpsqAiH3XcAvT0000</title>\n",
-       "<path fill=\"none\" stroke=\"#696969\" d=\"M865.5799,-253.4334C730.2267,-248.0853 439.471,-233.0141 196.8716,-196 195.7307,-195.8259 194.5822,-195.6451 193.4277,-195.458\"/>\n",
-       "<polygon fill=\"#696969\" stroke=\"#696969\" points=\"193.5525,-193.7045 188.3313,-194.5999 192.9713,-197.1559 193.5525,-193.7045\"/>\n",
-       "</g>\n",
-       "<!-- artifact_nelDyBfwvEIIAKcC0000 -->\n",
-       "<g id=\"node5\" class=\"node\">\n",
-       "<title>artifact_nelDyBfwvEIIAKcC0000</title>\n",
-       "<path fill=\"#f0fff0\" stroke=\"#065f46\" d=\"M351.6413,-196C351.6413,-196 218.1019,-196 218.1019,-196 212.1019,-196 206.1019,-190 206.1019,-184 206.1019,-184 206.1019,-170 206.1019,-170 206.1019,-164 212.1019,-158 218.1019,-158 218.1019,-158 351.6413,-158 351.6413,-158 357.6413,-158 363.6413,-164 363.6413,-170 363.6413,-170 363.6413,-184 363.6413,-184 363.6413,-190 357.6413,-196 351.6413,-196\"/>\n",
-       "<text text-anchor=\"start\" x=\"213.9868\" y=\"-185\" font-family=\"Helvetica,sans-Serif\" font-size=\"10.00\" fill=\"#000000\">📄 Visium SpatialData Example</text>\n",
-       "<text text-anchor=\"start\" x=\"221.644\" y=\"-175\" font-family=\"Monospace\" font-size=\"10.00\" fill=\"#c0c0c0\">uid=nelDyBfwvEIIAKcC0000</text>\n",
-       "<text text-anchor=\"start\" x=\"260.2817\" y=\"-165\" font-family=\"Monospace\" font-size=\"10.00\" fill=\"#c0c0c0\">suffix=.zarr</text>\n",
-       "</g>\n",
-       "<!-- run_xt2ErUgo7KKqUOOAnVad&#45;&gt;artifact_nelDyBfwvEIIAKcC0000 -->\n",
-       "<g id=\"edge3\" class=\"edge\">\n",
-       "<title>run_xt2ErUgo7KKqUOOAnVad&#45;&gt;artifact_nelDyBfwvEIIAKcC0000</title>\n",
-       "<path fill=\"none\" stroke=\"#696969\" d=\"M865.5983,-250.5795C756.0921,-242.2034 548.1927,-224.0868 372.8716,-196 371.5887,-195.7945 370.2964,-195.5823 368.9965,-195.364\"/>\n",
-       "<polygon fill=\"#696969\" stroke=\"#696969\" points=\"369.1745,-193.619 363.9498,-194.4937 368.5796,-197.0681 369.1745,-193.619\"/>\n",
-       "</g>\n",
-       "<!-- artifact_0I5aMNdh2UrECtFX0000 -->\n",
-       "<g id=\"node6\" class=\"node\">\n",
-       "<title>artifact_0I5aMNdh2UrECtFX0000</title>\n",
-       "<path fill=\"#f0fff0\" stroke=\"#065f46\" d=\"M587.651,-196C587.651,-196 394.0922,-196 394.0922,-196 388.0922,-196 382.0922,-190 382.0922,-184 382.0922,-184 382.0922,-170 382.0922,-170 382.0922,-164 388.0922,-158 394.0922,-158 394.0922,-158 587.651,-158 587.651,-158 593.651,-158 599.651,-164 599.651,-170 599.651,-170 599.651,-184 599.651,-184 599.651,-190 593.651,-196 587.651,-196\"/>\n",
-       "<text text-anchor=\"start\" x=\"389.9819\" y=\"-185\" font-family=\"Helvetica,sans-Serif\" font-size=\"10.00\" fill=\"#000000\">📄 PAS OME&#45;TIFF file, Neumann et al., 2020</text>\n",
-       "<text text-anchor=\"start\" x=\"424.3066\" y=\"-175\" font-family=\"Monospace\" font-size=\"10.00\" fill=\"#c0c0c0\">uid=0I5aMNdh2UrECtFX0000</text>\n",
-       "<text text-anchor=\"start\" x=\"471.0034\" y=\"-165\" font-family=\"Monospace\" font-size=\"10.00\" fill=\"#c0c0c0\">suffix=.tif</text>\n",
-       "</g>\n",
-       "<!-- run_xt2ErUgo7KKqUOOAnVad&#45;&gt;artifact_0I5aMNdh2UrECtFX0000 -->\n",
-       "<g id=\"edge4\" class=\"edge\">\n",
-       "<title>run_xt2ErUgo7KKqUOOAnVad&#45;&gt;artifact_0I5aMNdh2UrECtFX0000</title>\n",
-       "<path fill=\"none\" stroke=\"#696969\" d=\"M865.6207,-242.6434C794.2217,-230.1367 686.5908,-211.2834 604.9673,-196.9857\"/>\n",
-       "<polygon fill=\"#696969\" stroke=\"#696969\" points=\"604.8562,-195.1897 599.6292,-196.0507 604.2522,-198.6372 604.8562,-195.1897\"/>\n",
-       "</g>\n",
-       "<!-- artifact_CMBUzbNNCEDGCKcQ0000 -->\n",
-       "<g id=\"node7\" class=\"node\">\n",
-       "<title>artifact_CMBUzbNNCEDGCKcQ0000</title>\n",
-       "<path fill=\"#f0fff0\" stroke=\"#065f46\" d=\"M805.7212,-196C805.7212,-196 630.0219,-196 630.0219,-196 624.0219,-196 618.0219,-190 618.0219,-184 618.0219,-184 618.0219,-170 618.0219,-170 618.0219,-164 624.0219,-158 630.0219,-158 630.0219,-158 805.7212,-158 805.7212,-158 811.7212,-158 817.7212,-164 817.7212,-170 817.7212,-170 817.7212,-184 817.7212,-184 817.7212,-190 811.7212,-196 805.7212,-196\"/>\n",
-       "<text text-anchor=\"start\" x=\"625.9468\" y=\"-185\" font-family=\"Helvetica,sans-Serif\" font-size=\"10.00\" fill=\"#000000\">📄 PAS offsets file, Neumann et al., 2020</text>\n",
-       "<text text-anchor=\"start\" x=\"642.1514\" y=\"-175\" font-family=\"Monospace\" font-size=\"10.00\" fill=\"#c0c0c0\">uid=CMBUzbNNCEDGCKcQ0000</text>\n",
-       "<text text-anchor=\"start\" x=\"692.7202\" y=\"-165\" font-family=\"Monospace\" font-size=\"10.00\" fill=\"#c0c0c0\">suffix=.json</text>\n",
-       "</g>\n",
-       "<!-- run_xt2ErUgo7KKqUOOAnVad&#45;&gt;artifact_CMBUzbNNCEDGCKcQ0000 -->\n",
-       "<g id=\"edge5\" class=\"edge\">\n",
-       "<title>run_xt2ErUgo7KKqUOOAnVad&#45;&gt;artifact_CMBUzbNNCEDGCKcQ0000</title>\n",
-       "<path fill=\"none\" stroke=\"#696969\" d=\"M873.7519,-231.9756C842.7185,-221.0308 806.3463,-208.2031 776.5449,-197.6928\"/>\n",
-       "<polygon fill=\"#696969\" stroke=\"#696969\" points=\"777.1177,-196.0392 771.8202,-196.0265 775.9535,-199.34 777.1177,-196.0392\"/>\n",
+       "<!-- run_wW6GOHDq44lbrdKi08cr&#45;&gt;artifact_toCvpsqAiH3XcAvT0000 -->\n",
+       "<g id=\"edge8\" class=\"edge\">\n",
+       "<title>run_wW6GOHDq44lbrdKi08cr&#45;&gt;artifact_toCvpsqAiH3XcAvT0000</title>\n",
+       "<path fill=\"none\" stroke=\"#696969\" d=\"M986.577,-254.6356C835.2106,-251.0654 486.5147,-238.5348 196.8716,-196 195.7297,-195.8323 194.5804,-195.6575 193.425,-195.4761\"/>\n",
+       "<polygon fill=\"#696969\" stroke=\"#696969\" points=\"193.5425,-193.722 188.3253,-194.6403 192.9764,-197.176 193.5425,-193.722\"/>\n",
        "</g>\n",
        "<!-- artifact_1g3a41z0hggWNBrk0000 -->\n",
-       "<g id=\"node8\" class=\"node\">\n",
+       "<g id=\"node5\" class=\"node\">\n",
        "<title>artifact_1g3a41z0hggWNBrk0000</title>\n",
-       "<path fill=\"#f0fff0\" stroke=\"#065f46\" d=\"M1035.7671,-196C1035.7671,-196 847.976,-196 847.976,-196 841.976,-196 835.976,-190 835.976,-184 835.976,-184 835.976,-170 835.976,-170 835.976,-164 841.976,-158 847.976,-158 847.976,-158 1035.7671,-158 1035.7671,-158 1041.7671,-158 1047.7671,-164 1047.7671,-170 1047.7671,-170 1047.7671,-184 1047.7671,-184 1047.7671,-190 1041.7671,-196 1035.7671,-196\"/>\n",
-       "<text text-anchor=\"start\" x=\"843.9238\" y=\"-185\" font-family=\"Helvetica,sans-Serif\" font-size=\"10.00\" fill=\"#000000\">📄 Habib et al., 2017 Nature Methods, h5ad</text>\n",
-       "<text text-anchor=\"start\" x=\"875.0186\" y=\"-175\" font-family=\"Monospace\" font-size=\"10.00\" fill=\"#c0c0c0\">uid=1g3a41z0hggWNBrk0000</text>\n",
-       "<text text-anchor=\"start\" x=\"914.7695\" y=\"-165\" font-family=\"Monospace\" font-size=\"10.00\" fill=\"#c0c0c0\">suffix=.h5ad</text>\n",
+       "<path fill=\"#f0fff0\" stroke=\"#065f46\" d=\"M405.7671,-196C405.7671,-196 217.976,-196 217.976,-196 211.976,-196 205.976,-190 205.976,-184 205.976,-184 205.976,-170 205.976,-170 205.976,-164 211.976,-158 217.976,-158 217.976,-158 405.7671,-158 405.7671,-158 411.7671,-158 417.7671,-164 417.7671,-170 417.7671,-170 417.7671,-184 417.7671,-184 417.7671,-190 411.7671,-196 405.7671,-196\"/>\n",
+       "<text text-anchor=\"start\" x=\"213.9238\" y=\"-185\" font-family=\"Helvetica,sans-Serif\" font-size=\"10.00\" fill=\"#000000\">📄 Habib et al., 2017 Nature Methods, h5ad</text>\n",
+       "<text text-anchor=\"start\" x=\"245.0186\" y=\"-175\" font-family=\"Monospace\" font-size=\"10.00\" fill=\"#c0c0c0\">uid=1g3a41z0hggWNBrk0000</text>\n",
+       "<text text-anchor=\"start\" x=\"284.7695\" y=\"-165\" font-family=\"Monospace\" font-size=\"10.00\" fill=\"#c0c0c0\">suffix=.h5ad</text>\n",
        "</g>\n",
-       "<!-- run_xt2ErUgo7KKqUOOAnVad&#45;&gt;artifact_1g3a41z0hggWNBrk0000 -->\n",
-       "<g id=\"edge7\" class=\"edge\">\n",
-       "<title>run_xt2ErUgo7KKqUOOAnVad&#45;&gt;artifact_1g3a41z0hggWNBrk0000</title>\n",
-       "<path fill=\"none\" stroke=\"#696969\" d=\"M941.8716,-231.8681C941.8716,-222.2201 941.8716,-211.1228 941.8716,-201.4439\"/>\n",
-       "<polygon fill=\"#696969\" stroke=\"#696969\" points=\"943.6217,-201.2308 941.8716,-196.2309 940.1217,-201.2309 943.6217,-201.2308\"/>\n",
+       "<!-- run_wW6GOHDq44lbrdKi08cr&#45;&gt;artifact_1g3a41z0hggWNBrk0000 -->\n",
+       "<g id=\"edge3\" class=\"edge\">\n",
+       "<title>run_wW6GOHDq44lbrdKi08cr&#45;&gt;artifact_1g3a41z0hggWNBrk0000</title>\n",
+       "<path fill=\"none\" stroke=\"#696969\" d=\"M986.3181,-250.5102C866.6588,-241.539 628.1475,-222.0891 426.8716,-196 425.5985,-195.835 424.3179,-195.6665 423.031,-195.4948\"/>\n",
+       "<polygon fill=\"#696969\" stroke=\"#696969\" points=\"423.2278,-193.7555 418.0378,-194.8171 422.757,-197.2237 423.2278,-193.7555\"/>\n",
        "</g>\n",
        "<!-- artifact_O7CTVi6XjnfsceQ20000 -->\n",
-       "<g id=\"node9\" class=\"node\">\n",
+       "<g id=\"node6\" class=\"node\">\n",
        "<title>artifact_O7CTVi6XjnfsceQ20000</title>\n",
-       "<path fill=\"#f0fff0\" stroke=\"#065f46\" d=\"M1378.07,-196C1378.07,-196 1077.6732,-196 1077.6732,-196 1071.6732,-196 1065.6732,-190 1065.6732,-184 1065.6732,-184 1065.6732,-170 1065.6732,-170 1065.6732,-164 1071.6732,-158 1077.6732,-158 1077.6732,-158 1378.07,-158 1378.07,-158 1384.07,-158 1390.07,-164 1390.07,-170 1390.07,-170 1390.07,-184 1390.07,-184 1390.07,-190 1384.07,-196 1378.07,-196\"/>\n",
-       "<text text-anchor=\"start\" x=\"1073.5225\" y=\"-185\" font-family=\"Helvetica,sans-Serif\" font-size=\"10.00\" fill=\"#000000\">📄 Reference JSON for H5AD file, Habib et al., 2017 Nature Methods</text>\n",
-       "<text text-anchor=\"start\" x=\"1163.6162\" y=\"-175\" font-family=\"Monospace\" font-size=\"10.00\" fill=\"#c0c0c0\">uid=O7CTVi6XjnfsceQ20000</text>\n",
-       "<text text-anchor=\"start\" x=\"1202.7202\" y=\"-165\" font-family=\"Monospace\" font-size=\"10.00\" fill=\"#c0c0c0\">suffix=.json</text>\n",
+       "<path fill=\"#f0fff0\" stroke=\"#065f46\" d=\"M748.07,-196C748.07,-196 447.6732,-196 447.6732,-196 441.6732,-196 435.6732,-190 435.6732,-184 435.6732,-184 435.6732,-170 435.6732,-170 435.6732,-164 441.6732,-158 447.6732,-158 447.6732,-158 748.07,-158 748.07,-158 754.07,-158 760.07,-164 760.07,-170 760.07,-170 760.07,-184 760.07,-184 760.07,-190 754.07,-196 748.07,-196\"/>\n",
+       "<text text-anchor=\"start\" x=\"443.5225\" y=\"-185\" font-family=\"Helvetica,sans-Serif\" font-size=\"10.00\" fill=\"#000000\">📄 Reference JSON for H5AD file, Habib et al., 2017 Nature Methods</text>\n",
+       "<text text-anchor=\"start\" x=\"533.6162\" y=\"-175\" font-family=\"Monospace\" font-size=\"10.00\" fill=\"#c0c0c0\">uid=O7CTVi6XjnfsceQ20000</text>\n",
+       "<text text-anchor=\"start\" x=\"572.7202\" y=\"-165\" font-family=\"Monospace\" font-size=\"10.00\" fill=\"#c0c0c0\">suffix=.json</text>\n",
        "</g>\n",
-       "<!-- run_xt2ErUgo7KKqUOOAnVad&#45;&gt;artifact_O7CTVi6XjnfsceQ20000 -->\n",
-       "<g id=\"edge8\" class=\"edge\">\n",
-       "<title>run_xt2ErUgo7KKqUOOAnVad&#45;&gt;artifact_O7CTVi6XjnfsceQ20000</title>\n",
-       "<path fill=\"none\" stroke=\"#696969\" d=\"M1018.1386,-234.9332C1060.1176,-223.3376 1111.9871,-209.0101 1153.6399,-197.5046\"/>\n",
-       "<polygon fill=\"#696969\" stroke=\"#696969\" points=\"1154.3139,-199.134 1158.6675,-196.1158 1153.382,-195.7603 1154.3139,-199.134\"/>\n",
+       "<!-- run_wW6GOHDq44lbrdKi08cr&#45;&gt;artifact_O7CTVi6XjnfsceQ20000 -->\n",
+       "<g id=\"edge4\" class=\"edge\">\n",
+       "<title>run_wW6GOHDq44lbrdKi08cr&#45;&gt;artifact_O7CTVi6XjnfsceQ20000</title>\n",
+       "<path fill=\"none\" stroke=\"#696969\" d=\"M986.607,-243.0432C912.8412,-230.511 800.0233,-211.3441 714.8918,-196.8809\"/>\n",
+       "<polygon fill=\"#696969\" stroke=\"#696969\" points=\"715.0603,-195.1345 709.8378,-196.0222 714.474,-198.585 715.0603,-195.1345\"/>\n",
+       "</g>\n",
+       "<!-- artifact_nelDyBfwvEIIAKcC0000 -->\n",
+       "<g id=\"node7\" class=\"node\">\n",
+       "<title>artifact_nelDyBfwvEIIAKcC0000</title>\n",
+       "<path fill=\"#f0fff0\" stroke=\"#065f46\" d=\"M923.6413,-196C923.6413,-196 790.1019,-196 790.1019,-196 784.1019,-196 778.1019,-190 778.1019,-184 778.1019,-184 778.1019,-170 778.1019,-170 778.1019,-164 784.1019,-158 790.1019,-158 790.1019,-158 923.6413,-158 923.6413,-158 929.6413,-158 935.6413,-164 935.6413,-170 935.6413,-170 935.6413,-184 935.6413,-184 935.6413,-190 929.6413,-196 923.6413,-196\"/>\n",
+       "<text text-anchor=\"start\" x=\"785.9868\" y=\"-185\" font-family=\"Helvetica,sans-Serif\" font-size=\"10.00\" fill=\"#000000\">📄 Visium SpatialData Example</text>\n",
+       "<text text-anchor=\"start\" x=\"793.644\" y=\"-175\" font-family=\"Monospace\" font-size=\"10.00\" fill=\"#c0c0c0\">uid=nelDyBfwvEIIAKcC0000</text>\n",
+       "<text text-anchor=\"start\" x=\"832.2817\" y=\"-165\" font-family=\"Monospace\" font-size=\"10.00\" fill=\"#c0c0c0\">suffix=.zarr</text>\n",
+       "</g>\n",
+       "<!-- run_wW6GOHDq44lbrdKi08cr&#45;&gt;artifact_nelDyBfwvEIIAKcC0000 -->\n",
+       "<g id=\"edge5\" class=\"edge\">\n",
+       "<title>run_wW6GOHDq44lbrdKi08cr&#45;&gt;artifact_nelDyBfwvEIIAKcC0000</title>\n",
+       "<path fill=\"none\" stroke=\"#696969\" d=\"M1000.2258,-231.9756C971.8036,-221.0759 938.5119,-208.3087 911.1688,-197.8227\"/>\n",
+       "<polygon fill=\"#696969\" stroke=\"#696969\" points=\"911.7802,-196.183 906.4851,-196.0265 910.5269,-199.4509 911.7802,-196.183\"/>\n",
+       "</g>\n",
+       "<!-- artifact_0I5aMNdh2UrECtFX0000 -->\n",
+       "<g id=\"node8\" class=\"node\">\n",
+       "<title>artifact_0I5aMNdh2UrECtFX0000</title>\n",
+       "<path fill=\"#f0fff0\" stroke=\"#065f46\" d=\"M1159.651,-196C1159.651,-196 966.0922,-196 966.0922,-196 960.0922,-196 954.0922,-190 954.0922,-184 954.0922,-184 954.0922,-170 954.0922,-170 954.0922,-164 960.0922,-158 966.0922,-158 966.0922,-158 1159.651,-158 1159.651,-158 1165.651,-158 1171.651,-164 1171.651,-170 1171.651,-170 1171.651,-184 1171.651,-184 1171.651,-190 1165.651,-196 1159.651,-196\"/>\n",
+       "<text text-anchor=\"start\" x=\"961.9819\" y=\"-185\" font-family=\"Helvetica,sans-Serif\" font-size=\"10.00\" fill=\"#000000\">📄 PAS OME&#45;TIFF file, Neumann et al., 2020</text>\n",
+       "<text text-anchor=\"start\" x=\"996.3066\" y=\"-175\" font-family=\"Monospace\" font-size=\"10.00\" fill=\"#c0c0c0\">uid=0I5aMNdh2UrECtFX0000</text>\n",
+       "<text text-anchor=\"start\" x=\"1043.0034\" y=\"-165\" font-family=\"Monospace\" font-size=\"10.00\" fill=\"#c0c0c0\">suffix=.tif</text>\n",
+       "</g>\n",
+       "<!-- run_wW6GOHDq44lbrdKi08cr&#45;&gt;artifact_0I5aMNdh2UrECtFX0000 -->\n",
+       "<g id=\"edge6\" class=\"edge\">\n",
+       "<title>run_wW6GOHDq44lbrdKi08cr&#45;&gt;artifact_0I5aMNdh2UrECtFX0000</title>\n",
+       "<path fill=\"none\" stroke=\"#696969\" d=\"M1062.8716,-231.8681C1062.8716,-222.2201 1062.8716,-211.1228 1062.8716,-201.4439\"/>\n",
+       "<polygon fill=\"#696969\" stroke=\"#696969\" points=\"1064.6217,-201.2308 1062.8716,-196.2309 1061.1217,-201.2309 1064.6217,-201.2308\"/>\n",
+       "</g>\n",
+       "<!-- artifact_CMBUzbNNCEDGCKcQ0000 -->\n",
+       "<g id=\"node9\" class=\"node\">\n",
+       "<title>artifact_CMBUzbNNCEDGCKcQ0000</title>\n",
+       "<path fill=\"#f0fff0\" stroke=\"#065f46\" d=\"M1377.7212,-196C1377.7212,-196 1202.0219,-196 1202.0219,-196 1196.0219,-196 1190.0219,-190 1190.0219,-184 1190.0219,-184 1190.0219,-170 1190.0219,-170 1190.0219,-164 1196.0219,-158 1202.0219,-158 1202.0219,-158 1377.7212,-158 1377.7212,-158 1383.7212,-158 1389.7212,-164 1389.7212,-170 1389.7212,-170 1389.7212,-184 1389.7212,-184 1389.7212,-190 1383.7212,-196 1377.7212,-196\"/>\n",
+       "<text text-anchor=\"start\" x=\"1197.9468\" y=\"-185\" font-family=\"Helvetica,sans-Serif\" font-size=\"10.00\" fill=\"#000000\">📄 PAS offsets file, Neumann et al., 2020</text>\n",
+       "<text text-anchor=\"start\" x=\"1214.1514\" y=\"-175\" font-family=\"Monospace\" font-size=\"10.00\" fill=\"#c0c0c0\">uid=CMBUzbNNCEDGCKcQ0000</text>\n",
+       "<text text-anchor=\"start\" x=\"1264.7202\" y=\"-165\" font-family=\"Monospace\" font-size=\"10.00\" fill=\"#c0c0c0\">suffix=.json</text>\n",
+       "</g>\n",
+       "<!-- run_wW6GOHDq44lbrdKi08cr&#45;&gt;artifact_CMBUzbNNCEDGCKcQ0000 -->\n",
+       "<g id=\"edge7\" class=\"edge\">\n",
+       "<title>run_wW6GOHDq44lbrdKi08cr&#45;&gt;artifact_CMBUzbNNCEDGCKcQ0000</title>\n",
+       "<path fill=\"none\" stroke=\"#696969\" d=\"M1131.9036,-231.9756C1163.3526,-221.0308 1200.212,-208.2031 1230.4124,-197.6928\"/>\n",
+       "<polygon fill=\"#696969\" stroke=\"#696969\" points=\"1231.0534,-199.3228 1235.2004,-196.0265 1229.903,-196.0172 1231.0534,-199.3228\"/>\n",
        "</g>\n",
        "<!-- artifact_kWwG45Hr26KZUW3g0004 -->\n",
        "<g id=\"node10\" class=\"node\">\n",
        "<title>artifact_kWwG45Hr26KZUW3g0004</title>\n",
-       "<path fill=\"#f0fff0\" stroke=\"#065f46\" d=\"M1603.2427,-196C1603.2427,-196 1420.5004,-196 1420.5004,-196 1414.5004,-196 1408.5004,-190 1408.5004,-184 1408.5004,-184 1408.5004,-170 1408.5004,-170 1408.5004,-164 1414.5004,-158 1420.5004,-158 1420.5004,-158 1603.2427,-158 1603.2427,-158 1609.2427,-158 1615.2427,-164 1615.2427,-170 1615.2427,-170 1615.2427,-184 1615.2427,-184 1615.2427,-190 1609.2427,-196 1603.2427,-196\"/>\n",
-       "<text text-anchor=\"start\" x=\"1416.436\" y=\"-185\" font-family=\"Helvetica,sans-Serif\" font-size=\"10.00\" fill=\"#000000\">📄 Habib et al., 2017 Nature Methods, zarr</text>\n",
-       "<text text-anchor=\"start\" x=\"1439.7573\" y=\"-175\" font-family=\"Monospace\" font-size=\"10.00\" fill=\"#c0c0c0\">uid=kWwG45Hr26KZUW3g0004</text>\n",
-       "<text text-anchor=\"start\" x=\"1467.8188\" y=\"-165\" font-family=\"Monospace\" font-size=\"10.00\" fill=\"#c0c0c0\">suffix=.anndata.zarr</text>\n",
+       "<path fill=\"#f0fff0\" stroke=\"#065f46\" d=\"M1602.2427,-196C1602.2427,-196 1419.5004,-196 1419.5004,-196 1413.5004,-196 1407.5004,-190 1407.5004,-184 1407.5004,-184 1407.5004,-170 1407.5004,-170 1407.5004,-164 1413.5004,-158 1419.5004,-158 1419.5004,-158 1602.2427,-158 1602.2427,-158 1608.2427,-158 1614.2427,-164 1614.2427,-170 1614.2427,-170 1614.2427,-184 1614.2427,-184 1614.2427,-190 1608.2427,-196 1602.2427,-196\"/>\n",
+       "<text text-anchor=\"start\" x=\"1415.436\" y=\"-185\" font-family=\"Helvetica,sans-Serif\" font-size=\"10.00\" fill=\"#000000\">📄 Habib et al., 2017 Nature Methods, zarr</text>\n",
+       "<text text-anchor=\"start\" x=\"1438.7573\" y=\"-175\" font-family=\"Monospace\" font-size=\"10.00\" fill=\"#c0c0c0\">uid=kWwG45Hr26KZUW3g0004</text>\n",
+       "<text text-anchor=\"start\" x=\"1466.8188\" y=\"-165\" font-family=\"Monospace\" font-size=\"10.00\" fill=\"#c0c0c0\">suffix=.anndata.zarr</text>\n",
        "</g>\n",
-       "<!-- run_xt2ErUgo7KKqUOOAnVad&#45;&gt;artifact_kWwG45Hr26KZUW3g0004 -->\n",
+       "<!-- run_wW6GOHDq44lbrdKi08cr&#45;&gt;artifact_kWwG45Hr26KZUW3g0004 -->\n",
        "<g id=\"edge9\" class=\"edge\">\n",
-       "<title>run_xt2ErUgo7KKqUOOAnVad&#45;&gt;artifact_kWwG45Hr26KZUW3g0004</title>\n",
-       "<path fill=\"none\" stroke=\"#696969\" d=\"M1018.4021,-246.8074C1109.265,-235.6955 1265.3233,-215.9877 1398.8716,-196 1400.3472,-195.7792 1401.8333,-195.5549 1403.328,-195.3278\"/>\n",
-       "<polygon fill=\"#696969\" stroke=\"#696969\" points=\"1403.7635,-197.0315 1408.4407,-194.5444 1403.2333,-193.5719 1403.7635,-197.0315\"/>\n",
+       "<title>run_wW6GOHDq44lbrdKi08cr&#45;&gt;artifact_kWwG45Hr26KZUW3g0004</title>\n",
+       "<path fill=\"none\" stroke=\"#696969\" d=\"M1139.1224,-242.554C1211.3456,-229.8182 1320.559,-210.5596 1401.9473,-196.2076\"/>\n",
+       "<polygon fill=\"#696969\" stroke=\"#696969\" points=\"1402.6472,-197.8613 1407.2673,-195.2695 1402.0393,-194.4145 1402.6472,-197.8613\"/>\n",
        "</g>\n",
        "<!-- collection_obXokdzOnSH2tytJ0000 -->\n",
        "<g id=\"node11\" class=\"node\">\n",
        "<title>collection_obXokdzOnSH2tytJ0000</title>\n",
-       "<path fill=\"#f0fff0\" stroke=\"#065f46\" d=\"M1796.8198,-196C1796.8198,-196 1644.9233,-196 1644.9233,-196 1638.9233,-196 1632.9233,-190 1632.9233,-184 1632.9233,-184 1632.9233,-170 1632.9233,-170 1632.9233,-164 1638.9233,-158 1644.9233,-158 1644.9233,-158 1796.8198,-158 1796.8198,-158 1802.8198,-158 1808.8198,-164 1808.8198,-170 1808.8198,-170 1808.8198,-184 1808.8198,-184 1808.8198,-190 1802.8198,-196 1796.8198,-196\"/>\n",
-       "<text text-anchor=\"start\" x=\"1640.8975\" y=\"-185\" font-family=\"Helvetica,sans-Serif\" font-size=\"10.00\" fill=\"#000000\">🍱 View Habib17 (h5ad) in Vitessce</text>\n",
-       "<text text-anchor=\"start\" x=\"1656.5234\" y=\"-175\" font-family=\"Monospace\" font-size=\"10.00\" fill=\"#c0c0c0\">uid=obXokdzOnSH2tytJ0000</text>\n",
-       "<text text-anchor=\"start\" x=\"1689.8804\" y=\"-165\" font-family=\"Monospace\" font-size=\"10.00\" fill=\"#c0c0c0\">version=None</text>\n",
+       "<path fill=\"#f0fff0\" stroke=\"#065f46\" d=\"M1795.8198,-196C1795.8198,-196 1643.9233,-196 1643.9233,-196 1637.9233,-196 1631.9233,-190 1631.9233,-184 1631.9233,-184 1631.9233,-170 1631.9233,-170 1631.9233,-164 1637.9233,-158 1643.9233,-158 1643.9233,-158 1795.8198,-158 1795.8198,-158 1801.8198,-158 1807.8198,-164 1807.8198,-170 1807.8198,-170 1807.8198,-184 1807.8198,-184 1807.8198,-190 1801.8198,-196 1795.8198,-196\"/>\n",
+       "<text text-anchor=\"start\" x=\"1639.8975\" y=\"-185\" font-family=\"Helvetica,sans-Serif\" font-size=\"10.00\" fill=\"#000000\">🍱 View Habib17 (h5ad) in Vitessce</text>\n",
+       "<text text-anchor=\"start\" x=\"1655.5234\" y=\"-175\" font-family=\"Monospace\" font-size=\"10.00\" fill=\"#c0c0c0\">uid=obXokdzOnSH2tytJ0000</text>\n",
+       "<text text-anchor=\"start\" x=\"1688.8804\" y=\"-165\" font-family=\"Monospace\" font-size=\"10.00\" fill=\"#c0c0c0\">version=None</text>\n",
        "</g>\n",
-       "<!-- run_xt2ErUgo7KKqUOOAnVad&#45;&gt;collection_obXokdzOnSH2tytJ0000 -->\n",
+       "<!-- run_wW6GOHDq44lbrdKi08cr&#45;&gt;collection_obXokdzOnSH2tytJ0000 -->\n",
        "<g id=\"edge10\" class=\"edge\">\n",
-       "<title>run_xt2ErUgo7KKqUOOAnVad&#45;&gt;collection_obXokdzOnSH2tytJ0000</title>\n",
-       "<path fill=\"none\" stroke=\"#696969\" d=\"M1018.1158,-251.929C1144.4889,-244.5916 1405.1201,-226.9583 1623.8716,-196 1625.1725,-195.8159 1626.4823,-195.6258 1627.7994,-195.4303\"/>\n",
-       "<polygon fill=\"#696969\" stroke=\"#696969\" points=\"1628.2331,-197.1344 1632.9118,-194.6501 1627.705,-193.6745 1628.2331,-197.1344\"/>\n",
+       "<title>run_wW6GOHDq44lbrdKi08cr&#45;&gt;collection_obXokdzOnSH2tytJ0000</title>\n",
+       "<path fill=\"none\" stroke=\"#696969\" d=\"M1139.2262,-249.9316C1247.2672,-240.8654 1450.782,-222.0231 1622.8716,-196 1624.1706,-195.8036 1625.4788,-195.6019 1626.7943,-195.3954\"/>\n",
+       "<polygon fill=\"#696969\" stroke=\"#696969\" points=\"1627.2412,-197.0962 1631.9011,-194.5766 1626.6871,-193.6403 1627.2412,-197.0962\"/>\n",
        "</g>\n",
        "<!-- collection_HqfzZmkfYOy20ZNN0000 -->\n",
        "<g id=\"node12\" class=\"node\">\n",
        "<title>collection_HqfzZmkfYOy20ZNN0000</title>\n",
-       "<path fill=\"#f0fff0\" stroke=\"#065f46\" d=\"M2091.2155,-196C2091.2155,-196 1838.5276,-196 1838.5276,-196 1832.5276,-196 1826.5276,-190 1826.5276,-184 1826.5276,-184 1826.5276,-170 1826.5276,-170 1826.5276,-164 1832.5276,-158 1838.5276,-158 1838.5276,-158 2091.2155,-158 2091.2155,-158 2097.2155,-158 2103.2155,-164 2103.2155,-170 2103.2155,-170 2103.2155,-184 2103.2155,-184 2103.2155,-190 2097.2155,-196 2091.2155,-196\"/>\n",
-       "<text text-anchor=\"start\" x=\"1834.6997\" y=\"-185\" font-family=\"Helvetica,sans-Serif\" font-size=\"10.00\" fill=\"#000000\">🍱 View PAS OME&#45;TIFF, Neumann et al., 2020 in Vitessce</text>\n",
-       "<text text-anchor=\"start\" x=\"1897.2056\" y=\"-175\" font-family=\"Monospace\" font-size=\"10.00\" fill=\"#c0c0c0\">uid=HqfzZmkfYOy20ZNN0000</text>\n",
-       "<text text-anchor=\"start\" x=\"1933.8804\" y=\"-165\" font-family=\"Monospace\" font-size=\"10.00\" fill=\"#c0c0c0\">version=None</text>\n",
+       "<path fill=\"#f0fff0\" stroke=\"#065f46\" d=\"M2090.2155,-196C2090.2155,-196 1837.5276,-196 1837.5276,-196 1831.5276,-196 1825.5276,-190 1825.5276,-184 1825.5276,-184 1825.5276,-170 1825.5276,-170 1825.5276,-164 1831.5276,-158 1837.5276,-158 1837.5276,-158 2090.2155,-158 2090.2155,-158 2096.2155,-158 2102.2155,-164 2102.2155,-170 2102.2155,-170 2102.2155,-184 2102.2155,-184 2102.2155,-190 2096.2155,-196 2090.2155,-196\"/>\n",
+       "<text text-anchor=\"start\" x=\"1833.6997\" y=\"-185\" font-family=\"Helvetica,sans-Serif\" font-size=\"10.00\" fill=\"#000000\">🍱 View PAS OME&#45;TIFF, Neumann et al., 2020 in Vitessce</text>\n",
+       "<text text-anchor=\"start\" x=\"1896.2056\" y=\"-175\" font-family=\"Monospace\" font-size=\"10.00\" fill=\"#c0c0c0\">uid=HqfzZmkfYOy20ZNN0000</text>\n",
+       "<text text-anchor=\"start\" x=\"1932.8804\" y=\"-165\" font-family=\"Monospace\" font-size=\"10.00\" fill=\"#c0c0c0\">version=None</text>\n",
        "</g>\n",
-       "<!-- run_xt2ErUgo7KKqUOOAnVad&#45;&gt;collection_HqfzZmkfYOy20ZNN0000 -->\n",
+       "<!-- run_wW6GOHDq44lbrdKi08cr&#45;&gt;collection_HqfzZmkfYOy20ZNN0000 -->\n",
        "<g id=\"edge11\" class=\"edge\">\n",
-       "<title>run_xt2ErUgo7KKqUOOAnVad&#45;&gt;collection_HqfzZmkfYOy20ZNN0000</title>\n",
-       "<path fill=\"none\" stroke=\"#696969\" d=\"M1018.1637,-252.3219C1170.4394,-244.6386 1522.8125,-225.1466 1817.8716,-196 1819.016,-195.887 1820.1652,-195.7721 1821.3187,-195.6554\"/>\n",
-       "<polygon fill=\"#696969\" stroke=\"#696969\" points=\"1821.6077,-197.3851 1826.4026,-195.1332 1821.25,-193.9034 1821.6077,-197.3851\"/>\n",
+       "<title>run_wW6GOHDq44lbrdKi08cr&#45;&gt;collection_HqfzZmkfYOy20ZNN0000</title>\n",
+       "<path fill=\"none\" stroke=\"#696969\" d=\"M1139.2411,-251.168C1275.5232,-242.2676 1569.5338,-221.8097 1816.8716,-196 1818.0153,-195.8807 1819.1639,-195.7597 1820.3169,-195.6372\"/>\n",
+       "<polygon fill=\"#696969\" stroke=\"#696969\" points=\"1820.6142,-197.3654 1825.3983,-195.0905 1820.2398,-193.8855 1820.6142,-197.3654\"/>\n",
        "</g>\n",
        "</g>\n",
        "</svg>\n"
@@ -1899,7 +2381,13 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "editable": true,
+    "slideshow": {
+     "slide_type": ""
+    },
+    "tags": []
+   },
    "source": [
     ":::{note}\n",
     "\n",
@@ -1910,14 +2398,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 46,
-   "metadata": {},
+   "execution_count": 38,
+   "metadata": {
+    "editable": true,
+    "slideshow": {
+     "slide_type": ""
+    },
+    "tags": []
+   },
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[93m!\u001b[0m cells [(0, 4), (4, 8), (22, 24)] were not run consecutively\n"
+      "\u001b[93m!\u001b[0m cells [(0, None), (None, 1)] were not run consecutively\n"
      ]
     },
     {
@@ -1931,8 +2425,8 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[92m→\u001b[0m finished Run('xt2ErUgo') after 0d 0h 0m 58s at 2024-12-04 16:01:54 UTC\n",
-      "\u001b[92m→\u001b[0m go to: https://lamin.ai/vitessce/examples/transform/XmcumVqvKZd30002\n",
+      "\u001b[92m→\u001b[0m finished Run('wW6GOHDq') after 0d 0h 1m 9s at 2024-12-04 16:12:04 UTC\n",
+      "\u001b[92m→\u001b[0m go to: https://lamin.ai/vitessce/examples/transform/BZhZQ6uIbkWv0000\n",
       "\u001b[92m→\u001b[0m if you want to update your notebook without re-running it, use `lamin save /Users/markkeller/research/dbmi/vitessce/lamin/lamin-spatial/docs/vitessce.ipynb`\n"
      ]
     }
@@ -1944,7 +2438,13 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "editable": true,
+    "slideshow": {
+     "slide_type": ""
+    },
+    "tags": []
+   },
    "source": [
     ":::{dropdown} Upload speed\n",
     "\n",

--- a/docs/vitessce.ipynb
+++ b/docs/vitessce.ipynb
@@ -4,7 +4,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "[![](https://img.shields.io/badge/Source%20on%20GitHub-orange)](https://github.com/laminlabs/lamin-spatial/blob/main/docs/vitessce.ipynb) [![hub](https://img.shields.io/badge/View%20on%20LaminHub-mediumseagreen)](https://lamin.ai/laminlabs/lamindata/transform/hqtT4OTr5Tiq5zKv/URbaThYhljgXbZEzgj5x)"
+    "[![](https://img.shields.io/badge/Source%20on%20GitHub-orange)](https://github.com/laminlabs/lamin-spatial/blob/main/docs/vitessce.ipynb) [![hub](https://img.shields.io/badge/View%20on%20lamin.ai-mediumseagreen)](https://lamin.ai/vitessce/examples/transform/BZhZQ6uIbkWv)"
    ]
   },
   {
@@ -70,7 +70,7 @@
     "import json\n",
     "\n",
     "# [optional] track the current notebook or script\n",
-    "ln.track(\"BZhZQ6uIbkWv0000\")"
+    "ln.track(\"BZhZQ6uIbkWv0001\")"
    ]
   },
   {
@@ -1477,8 +1477,8 @@
    },
    "outputs": [],
    "source": [
-    "# [optional] finish run context and auto-save the notebook\n",
-    "ln.finish()"
+    "# [optional] finish run and auto-save the notebook\n",
+    "# ln.finish()"
    ]
   },
   {
@@ -1534,7 +1534,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3 (ipykernel)",
+   "display_name": "py310",
    "language": "python",
    "name": "python3"
   },
@@ -1548,7 +1548,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.0"
+   "version": "3.10.15"
   }
  },
  "nbformat": 4,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,8 @@ dev = [
 use_case = [
     "wetlab",
     "findrefs",
-    "vitessce",
+    "vitessce[all]>=3.5.0",
+    "generate-tiff-offsets>=0.1.9",
     "starlette",
     "duckdb",
     "s3fs>=2024.10.0"  # gets downgraded by vitessce/starlette but needs to be recent


### PR DESCRIPTION
This PR updates the Vitessce tutorial notebook.

As we discussed previously, I tried to simplify the AnnData pre-processing steps and have added sections for H5AD-based AnnData objects, SpatialData objects, OME-TIFF images, and OME-Zarr images.

I have added `key=` to the Artifact creation steps as requested on Slack. 

There are two known minor issues:
- The issue with HTTP Range requests as shared on slack.
- The OME-TIFF files are configured like

```json
     {
        "fileType": "image.ome-tiff",
        "url": "https://lamin.ai/storage/s3/lamin-us-east-1/TwPtYAyQwlyO%2F/.lamindb/0I5aMNdh2UrECtFX0000.tif",
        "options": {
          "offsetsUrl": "https://lamin-us-east-1.s3-lamin-us-east-1.amazonaws.com/TwPtYAyQwlyO/.lamindb/CMBUzbNNCEDGCKcQ0000.json"
        }
      }
```
upon clicking the Vitessce button, the `options.offsetsUrl` (when present) will need to be updated to match the `https://lamin.ai/storage/s3/lamin-us-east-1/` URL prefix (analogous to the `options.refSpecUrl` for the `anndata.h5ad` dataset configurations). See example [.vitessce.json artifact](https://lamin.ai/vitessce/examples/artifact/QtF1OEtYyUe1EQ1k0000) and [collection](https://lamin.ai/vitessce/examples/collection/HqfzZmkfYOy20ZNN0000).