### PR TITLE
✨ Add SpatialDataCurator

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -120,3 +120,5 @@ docs/*.png
 *.ome.tiff
 *.zarr.zip
 test-rxrx/
+run-tests
+test.ipynb

--- a/lamin_spatial/__init__.py
+++ b/lamin_spatial/__init__.py
@@ -6,4 +6,4 @@ Import the package::
 
 """
 
-__version__ = "0.0.1"  # denote a pre-release for 0.1.0 with 0.1rc1
+__version__ = "0.1.0"  # denote a pre-release for 0.1.0 with 0.1rc1

--- a/lamin_spatial/__init__.py
+++ b/lamin_spatial/__init__.py
@@ -1,4 +1,4 @@
-"""Manage Spatial data using LaminDB.
+"""Manage spatial data using LaminDB.
 
 Import the package::
 
@@ -7,3 +7,5 @@ Import the package::
 """
 
 __version__ = "0.1.0"  # denote a pre-release for 0.1.0 with 0.1rc1
+
+from spatialdata_curator import SpatialDataCurator

--- a/lamin_spatial/__init__.py
+++ b/lamin_spatial/__init__.py
@@ -8,4 +8,4 @@ Import the package::
 
 __version__ = "0.1.0"  # denote a pre-release for 0.1.0 with 0.1rc1
 
-from spatialdata_curator import SpatialDataCurator
+from lamin_spatial.spatialdata_curator import SpatialDataCurator

--- a/lamin_spatial/spatialdata_curator.py
+++ b/lamin_spatial/spatialdata_curator.py
@@ -268,10 +268,10 @@ class SpatialDataCurator:
 
         if accessor == self._sample_metadata_key:
             if key not in self._sample_metadata.columns:
-                raise ValueError(f"Key '{key}' not present in '{accessor}'!")
+                raise ValueError(f"key '{key}' not present in '{accessor}'!")
         else:
             if key not in self._sdata.tables[accessor].obs.columns:
-                raise ValueError(f"Key '{key}' not present in '{accessor}'!")
+                raise ValueError(f"key '{key}' not present in '{accessor}'!")
 
         if accessor in self._table_adata_curators.keys():
             adata_curator = self._table_adata_curators[accessor]

--- a/lamin_spatial/spatialdata_curator.py
+++ b/lamin_spatial/spatialdata_curator.py
@@ -17,7 +17,7 @@ from lamindb.core._data import add_labels
 from lamindb.core._feature_manager import parse_feature_sets_from_anndata
 from lamindb.core._settings import settings
 from lamindb.core.exceptions import ValidationError
-from lnschema_core import Artifact, Collection, Feature, FeatureSet, Record, Run
+from lnschema_core.models import Artifact, Collection, Feature, FeatureSet, Record, Run
 from lnschema_core.types import FieldAttr
 from spatialdata import SpatialData
 

--- a/lamin_spatial/spatialdata_curator.py
+++ b/lamin_spatial/spatialdata_curator.py
@@ -1,9 +1,21 @@
-from typing import Iterable
+from typing import Any, Iterable, MutableMapping
 
+import lamindb_setup as ln_setup
 import pandas as pd
-from lamindb._curate import AnnDataCurator, CurateLookup, DataFrameCurator
+from lamin_utils import colors, logger
+from lamindb._curate import (
+    AnnDataCurator,
+    CurateLookup,
+    DataFrameCurator,
+    _ref_is_name,
+    check_registry_organism,
+    get_current_filter_kwargs,
+)
+from lamindb.core._data import add_labels
+from lamindb.core._feature_manager import parse_feature_sets_from_anndata
+from lamindb.core._settings import settings
 from lamindb.core.exceptions import ValidationError
-from lnschema_core import Artifact, Feature, Record, Run
+from lnschema_core import Artifact, Collection, Feature, FeatureSet, Record, Run
 from lnschema_core.types import FieldAttr
 from spatialdata import SpatialData
 
@@ -22,6 +34,7 @@ class SpatialDataCurator:
         sdata: The SpatialData object to curate.
         var_index: A dictionary mapping table keys to the ``.var`` indices.
         categoricals: A nested dictionary mapping an accessor to dictionaries that map columns to a registry field.
+            The key 'sample' must be used for sample level metadata that is stored in the Spatialdata object and not one of the tables.
         using_key: A reference LaminDB instance.
         verbosity: The verbosity level.
         organism: The organism name.
@@ -68,24 +81,26 @@ class SpatialDataCurator:
         self._kwargs = {"organism": organism} if organism else {}
         self._var_fields = var_index
         self._verify_accessor(self._var_fields.keys())
-        self._obs_fields = self._parse_categoricals(categoricals)
-        self._tables = set(self._var_fields.keys()) | set(self._obs_fields.keys())
+        self._categoricals = categoricals  # TODO Verify existence and no overlap
+        self._tables = set(self._var_fields.keys()) | set(
+            self._categoricals.keys() - {"sample"}
+        )
         self._using_key = using_key
         self._verbosity = verbosity
-        self._obs_df_curator = None
+        self._sample_df_curator = None
         self._sample_metadata = self._sdata.get_attrs(
-            key="spatialdata-db", return_as="df", flatten=False
+            key="spatialdata-db", return_as="df", flatten=True
         )  # this key will need to be adapted in the future
 
-        if "obs" in self._tables:
-            self._obs_df_curator = DataFrameCurator(
+        if "sample" in self._categoricals.keys():
+            self._sample_df_curator = DataFrameCurator(
                 df=self._sample_metadata,
                 columns=Feature.name,
-                categoricals=self._obs_fields.get("obs", {}),
+                categoricals=self._categoricals.get("sample", {}),
                 using_key=using_key,
                 verbosity=verbosity,
-                sources=self._sources.get("obs"),
-                exclude=self._exclude.get("obs"),
+                sources=self._sources.get("sample"),
+                exclude=self._exclude.get("sample"),
                 check_valid_keys=False,
                 **self._kwargs,
             )
@@ -93,7 +108,7 @@ class SpatialDataCurator:
             table: AnnDataCurator(
                 data=sdata[table],
                 var_index=var_index.get(table),
-                categoricals=self._obs_fields.get(table),
+                categoricals=self._categoricals.get(table),
                 using_key=using_key,
                 verbosity=verbosity,
                 sources=self._sources.get(table),
@@ -101,7 +116,6 @@ class SpatialDataCurator:
                 **self._kwargs,
             )
             for table in self._tables
-            if table != "obs"
         }
         self._non_validated = None
 
@@ -111,9 +125,9 @@ class SpatialDataCurator:
         return self._var_fields
 
     @property
-    def categoricals(self) -> dict:
-        """Return the obs fields to validate against."""
-        return self._obs_fields
+    def categoricals(self) -> dict[str, dict[str, FieldAttr]]:
+        """Return the categoricals fields to validate against."""
+        return self._categoricals
 
     @property
     def non_validated(self) -> dict[str, dict[str, list[str]]]:
@@ -131,10 +145,6 @@ class SpatialDataCurator:
             ):
                 raise ValidationError(f"Accessor '{acc} does not exist!")
 
-    def _parse_categoricals(self, categoricals: dict[str, FieldAttr]) -> dict:
-        """Parse the categorical fields."""
-        pass
-
     def lookup(
         self, using_key: str | None = None, public: bool = False
     ) -> CurateLookup:
@@ -144,35 +154,76 @@ class SpatialDataCurator:
             using_key: The instance where the lookup is performed.
                 if "public", the lookup is performed on the public reference.
         """
-        pass
-
-    def _replace_synonyms(
-        self, key: str, syn_mapper: dict, values: pd.Series | pd.Index
-    ):
-        pass
+        return CurateLookup(
+            categoricals=self.categoricals,
+            slots={
+                **{f"{k}_var_index": v for k, v in self._var_fields.items()},
+            },
+            using_key=using_key or self._using_key,
+            public=public,
+        )
 
     def _update_registry_all(self):
         """Update all registries."""
-        pass
+        if self._sample_df_curator is not None:
+            self._sample_df_curator._update_registry_all(
+                validated_only=True, **self._kwargs
+            )
+        for _, adata_curator in self._mod_adata_curators.items():
+            adata_curator._update_registry_all(validated_only=True, **self._kwargs)
+
+    def add_new_from_var_index(self, table: str, organism: str | None = None, **kwargs):
+        """Update variable records.
+
+        Args:
+            table: The table key.
+            organism: The organism name.
+            **kwargs: Additional keyword arguments to pass to create new records.
+        """
+        self._kwargs.update({"organism": organism} if organism else {})
+        self._table_adata_curators[table].add_new_from_var_index(
+            **self._kwargs, **kwargs
+        )
 
     def add_new_from(
         self,
         key: str,
-        modality: str | None = None,
+        accessor: str | None = None,
         organism: str | None = None,
         **kwargs,
     ):
-        pass
-
-    def standardize(self, key: str) -> None:
-        """Replace synonyms with standardized values.
-
-        Modifies the input dataset inplace.
+        """Add validated & new categories.
 
         Args:
-            key: The key referencing the column in the DataFrame to standardize.
+            key: The key referencing the slot in the DataFrame.
+            accessor: The accessor key such as 'sample' or 'table x'.
+            organism: The organism name.
+            **kwargs: Additional keyword arguments to pass to create new records.
         """
-        pass
+        if len(kwargs) > 0 and key == "all":
+            raise ValueError("Cannot pass additional arguments to 'all' key!")
+
+        self._kwargs.update({"organism": organism} if organism else {})
+        if accessor in self._table_adata_curators:
+            adata_curator = self._table_adata_curators[accessor]
+            adata_curator.add_new_from(key=key, **self._kwargs, **kwargs)
+        if accessor == "sample":
+            self._sample_df_curator.add_new_from(key=key, **self._kwargs, **kwargs)
+
+    def standardize(self, key: str, accessor: str | None = None):
+        """Replace synonyms with standardized values.
+
+        Args:
+            key: The key referencing the slot in the `MuData`.
+            accessor: The accessor key such as 'sample' or 'table x'.
+
+        Inplace modification of the dataset.
+        """
+        if accessor in self._table_adata_curators:
+            adata_curator = self._table_adata_curators[accessor]
+            adata_curator.standardize(key=key)
+        if accessor == "sample":
+            self._sample_df_curator.standardize(key=key)
 
     def validate(self, organism: str | None = None) -> bool:
         """Validate variables and categorical observations.
@@ -185,8 +236,43 @@ class SpatialDataCurator:
             organism: The organism name.
 
         Returns:
-            Whether the DataFrame is validated.
+            Whether the SpatialData object is validated.
         """
+        from lamindb.core._settings import settings
+
+        self._kwargs.update({"organism": organism} if organism else {})
+        if self._using_key is not None and self._using_key != "default":
+            logger.important(
+                f"validating using registries of instance {colors.italic(self._using_key)}"
+            )
+
+        # add all validated records to the current instance
+        verbosity = settings.verbosity
+        try:
+            settings.verbosity = "error"
+            self._update_registry_all()
+        finally:
+            settings.verbosity = verbosity
+
+        self._non_validated = {}  # type: ignore
+
+        obs_validated = True
+        if self._sample_df_curator:
+            logger.info('validating categoricals of "sample" metadata...')
+            obs_validated &= self._sample_df_curator.validate(**self._kwargs)
+            self._non_validated["obs"] = self._sample_df_curator.non_validated  # type: ignore
+            logger.print("")
+
+        mods_validated = True
+        for table, adata_curator in self._table_adata_curators.items():
+            logger.info(f'validating categoricals in table "{table}"...')
+            mods_validated &= adata_curator.validate(**self._kwargs)
+            if len(adata_curator.non_validated) > 0:
+                self._non_validated[table] = adata_curator.non_validated  # type: ignore
+            logger.print("")
+
+        self._validated = obs_validated & mods_validated
+        return self._validated
 
     def save_artifact(
         self,
@@ -207,3 +293,158 @@ class SpatialDataCurator:
         Returns:
             A saved artifact record.
         """
+        if not self._validated:
+            self.validate()
+            if not self._validated:
+                raise ValidationError("Dataset does not validate. Please curate.")
+
+        verbosity = settings.verbosity
+        try:
+            settings.verbosity = "warning"
+
+            self._artifact = Artifact(
+                self._sdata,
+                description=description,
+                columns_field=self._var_fields,
+                fields=self.categoricals,
+                key=key,
+                revises=revises,
+                run=run,
+                **self._kwargs,
+            )
+            # According to Tim it's not easy to calculate the number of observations.
+            # We'd have to write custom code to iterate over labels (which might not even exist at that point)
+            self._artifact._accessor = "spatialdata"
+            self._artifact.save()
+
+            # Link featuresets
+            feature_kwargs = check_registry_organism(
+                (list(self._var_fields.values())[0].field.model),
+                self._kwargs.get("organism"),
+            )
+
+            def _add_set_from_spatialdata(
+                host: Artifact | Collection | Run,
+                var_fields: dict[str, FieldAttr],
+                obs_fields: dict[str, FieldAttr] = None,
+                mute: bool = False,
+                organism: str | Record | None = None,
+            ):
+                """Add FeatureSets from SpatialData."""
+                if obs_fields is None:
+                    obs_fields = {}
+                assert host._accessor == "spatialdata"
+
+                sdata = host.load()
+                feature_sets = {}
+
+                # sample features
+                sample_features = Feature.from_values(self._sample_metadata.columns)
+                if len(sample_features) > 0:
+                    feature_sets["sample"] = FeatureSet(features=sample_features)
+
+                # table features
+                for table, field in var_fields.items():
+                    table_fs = parse_feature_sets_from_anndata(
+                        sdata[table],
+                        var_field=field,
+                        obs_field=obs_fields.get(table, Feature.name),
+                        mute=mute,
+                        organism=organism,
+                    )
+                    for k, v in table_fs.items():
+                        feature_sets[f"['{table}'].{k}"] = v
+
+                def _unify_feature_sets_by_hash(
+                    feature_sets: MutableMapping[str, FeatureSet],
+                ):
+                    unique_values: dict[str, Any] = {}
+
+                    for key, value in feature_sets.items():
+                        value_hash = (
+                            value.hash
+                        )  # Assuming each value has a .hash attribute
+                        if value_hash in unique_values:
+                            feature_sets[key] = unique_values[value_hash]
+                        else:
+                            unique_values[value_hash] = value
+
+                    return feature_sets
+
+                # link feature sets
+                host._feature_sets = _unify_feature_sets_by_hash(feature_sets)
+                host.save()
+
+            _add_set_from_spatialdata(
+                self._artifact, var_fields=self._var_fields, **feature_kwargs
+            )
+
+            # Link labels
+            def _add_labels_from_spatialdata(
+                data,
+                artifact: Artifact,
+                fields: dict[str, FieldAttr],
+                feature_ref_is_name: bool | None = None,
+            ):
+                """Add Labels from SpatialData."""
+                features = Feature.lookup().dict()
+                for key, field in fields.items():
+                    feature = features.get(key)
+                    registry = field.field.model
+                    filter_kwargs = check_registry_organism(
+                        registry, self._kwargs.get("organism")
+                    )
+                    filter_kwargs_current = get_current_filter_kwargs(
+                        registry, filter_kwargs
+                    )
+                    df = data if isinstance(data, pd.DataFrame) else data.obs
+                    labels = registry.from_values(
+                        df[key],
+                        field=field,
+                        **filter_kwargs_current,
+                    )
+                    if len(labels) == 0:
+                        continue
+                    label_ref_is_name = None
+                    if hasattr(registry, "_name_field"):
+                        label_ref_is_name = field.field.name == registry._name_field
+                    add_labels(
+                        artifact,
+                        records=labels,
+                        feature=feature,
+                        feature_ref_is_name=feature_ref_is_name,
+                        label_ref_is_name=label_ref_is_name,
+                        from_curator=True,
+                    )
+
+            for accessor, accessor_fields in self._categoricals.items():
+                column_field = self._var_fields.get(accessor)
+                if accessor == "sample":
+                    _add_labels_from_spatialdata(
+                        self._sample_metadata,
+                        self._artifact,
+                        accessor_fields,
+                        feature_ref_is_name=(
+                            None if column_field is None else _ref_is_name(column_field)
+                        ),
+                    )
+                else:
+                    _add_labels_from_spatialdata(
+                        self._sdata.tables[accessor],
+                        self._artifact,
+                        accessor_fields,
+                        feature_ref_is_name=(
+                            None if column_field is None else _ref_is_name(column_field)
+                        ),
+                    )
+
+        finally:
+            settings.verbosity = verbosity
+
+        slug = ln_setup.settings.instance.slug
+        if ln_setup.settings.instance.is_remote:  # pragma: no cover
+            logger.important(
+                f"go to https://lamin.ai/{slug}/artifact/{self._artifact.uid}"
+            )
+
+        return self._artifact

--- a/lamin_spatial/spatialdata_curator.py
+++ b/lamin_spatial/spatialdata_curator.py
@@ -263,11 +263,22 @@ class SpatialDataCurator:
 
         Inplace modification of the dataset.
         """
+        if len(self.non_validated) == 0:
+            logger.warning("values are already standardized")
+            return
+
+        if accessor == self._sample_metadata_key:
+            if key not in self._sample_metadata.columns:
+                raise ValueError(f"Key '{key}' not present in '{accessor}'!")
+        else:
+            if key not in self._sdata.tables[accessor].obs.columns:
+                raise ValueError(f"Key '{key}' not present in '{accessor}'!")
+
         if accessor in self._table_adata_curators.keys():
             adata_curator = self._table_adata_curators[accessor]
-            adata_curator.standardize(key=key)
+            adata_curator.standardize(key)
         if accessor == self._sample_metadata_key:
-            self._sample_df_curator.standardize(key=key)
+            self._sample_df_curator.standardize(key)
 
     def validate(self, organism: str | None = None) -> bool:
         """Validate variables and categorical observations.

--- a/lamin_spatial/spatialdata_curator.py
+++ b/lamin_spatial/spatialdata_curator.py
@@ -81,9 +81,7 @@ class SpatialDataCurator:
         self._sdata = sdata
         self._kwargs = {"organism": organism} if organism else {}
         self._var_fields = var_index
-        # TODO we should properly check for sample. This currently fails because we hard coded spatialdata-db as the attrs key
-        self._verify_accessor(self._var_fields.keys() - {"sample"})
-        # TODO consider splitting this up into two types of keys -> sap: for sample and tab: for table stuff
+        self._verify_accessor(self._var_fields.keys())
         self._categoricals = categoricals
         self._tables = set(self._var_fields.keys()) | set(
             self._categoricals.keys() - {"sample"}
@@ -92,7 +90,7 @@ class SpatialDataCurator:
         self._verbosity = verbosity
         self._sample_df_curator = None
         self._sample_metadata = self._sdata.get_attrs(
-            key="spatialdata-db", return_as="df", flatten=True
+            key="sample", return_as="df", flatten=True
         )  # this key will need to be adapted in the future
         self._validated = False
 
@@ -273,7 +271,7 @@ class SpatialDataCurator:
 
         mods_validated = True
         for table, adata_curator in self._table_adata_curators.items():
-            logger.info(f'validating categoricals in table "{table}"...')
+            logger.info(f"validating categoricals in table '{table}'...")
             mods_validated &= adata_curator.validate(**self._kwargs)
             if len(adata_curator.non_validated) > 0:
                 self._non_validated[table] = adata_curator.non_validated  # type: ignore

--- a/lamin_spatial/spatialdata_curator.py
+++ b/lamin_spatial/spatialdata_curator.py
@@ -257,6 +257,9 @@ class SpatialDataCurator:
         if accessor == self._sample_metadata_key:
             self._sample_df_curator.add_new_from(key=key, **self._kwargs, **kwargs)
 
+        if len(self.non_validated[accessor].values()) == 0:
+            self.non_validated.pop(accessor)
+
     def standardize(self, key: str, accessor: str | None = None):
         """Replace synonyms with standardized values.
 

--- a/lamin_spatial/spatialdata_curator.py
+++ b/lamin_spatial/spatialdata_curator.py
@@ -219,6 +219,8 @@ class SpatialDataCurator:
             organism: The organism name.
             **kwargs: Additional keyword arguments to pass to create new records.
         """
+        if self._non_validated is None:
+            raise ValidationError("Run .validate() first.")
         self._kwargs.update({"organism": organism} if organism else {})
         self._table_adata_curators[table].add_new_from_var_index(
             **self._kwargs, **kwargs
@@ -239,6 +241,9 @@ class SpatialDataCurator:
             organism: The organism name.
             **kwargs: Additional keyword arguments to pass to create new records.
         """
+        if self._non_validated is None:
+            raise ValidationError("Run .validate() first.")
+
         if len(kwargs) > 0 and key == "all":
             raise ValueError("Cannot pass additional arguments to 'all' key!")
 

--- a/lamin_spatial/spatialdata_curator.py
+++ b/lamin_spatial/spatialdata_curator.py
@@ -1,0 +1,209 @@
+from typing import Iterable
+
+import pandas as pd
+from lamindb._curate import AnnDataCurator, CurateLookup, DataFrameCurator
+from lamindb.core.exceptions import ValidationError
+from lnschema_core import Artifact, Feature, Record, Run
+from lnschema_core.types import FieldAttr
+from spatialdata import SpatialData
+
+
+class SpatialDataCurator:
+    """Curation flow for a ``Spatialdata`` object.
+
+    See also :class:`~lamindb.Curator`.
+
+    Note that if genes or other measurements are removed from the SpatialData object,
+    the object should be recreated using :meth:`~lamindb.Curator.from_spatialdata`.
+
+    In the following docstring, an accessor refers to either a ``.table`` or the sample level metadata.
+
+    Args:
+        sdata: The SpatialData object to curate.
+        var_index: A dictionary mapping table keys to the ``.var`` indices.
+        categoricals: A nested dictionary mapping an accessor to dictionaries that map columns to a registry field.
+        using_key: A reference LaminDB instance.
+        verbosity: The verbosity level.
+        organism: The organism name.
+        sources: A dictionary mapping an accessor to dictionaries that map columns to Source records.
+        exclude: A dictionary mapping an accessor to dictionaries of column names to values to exclude from validation.
+            When specific :class:`~bionty.Source` instances are pinned and may lack default values (e.g., "unknown" or "na"),
+            using the exclude parameter ensures they are not validated.
+
+    Examples:
+        >>> import bionty as bt
+        >>> curator = ln.Curator.from_spatialdata(
+        ...     sdata,
+        ...     var_index={
+        ...         "table_1": bt.Gene.ensembl_gene_id,
+        ...     },
+        ...     categoricals={
+        ...         "table1":
+        ...             {"cell_type_ontology_id": bt.CellType.ontology_id, "donor_id": ln.ULabel.name},
+        ...         "sample":
+        ...             {"experimental_factor": bt.ExperimentalFactor.name},
+        ...     },
+        ...     organism="human",
+        ... )
+    """
+
+    def __init__(
+        self,
+        sdata: SpatialData,
+        var_index: dict[str, FieldAttr],
+        categoricals: dict[str, dict[str, FieldAttr]] | None = None,
+        using_key: str | None = None,
+        verbosity: str = "hint",
+        organism: str | None = None,
+        sources: dict[str, dict[str, Record]] | None = None,
+        exclude: dict[str, dict] | None = None,
+    ) -> None:
+        if sources is None:
+            sources = {}
+        self._sources = sources
+        if exclude is None:
+            exclude = {}
+        self._exclude = exclude
+        self._sdata = sdata
+        self._kwargs = {"organism": organism} if organism else {}
+        self._var_fields = var_index
+        self._verify_accessor(self._var_fields.keys())
+        self._obs_fields = self._parse_categoricals(categoricals)
+        self._tables = set(self._var_fields.keys()) | set(self._obs_fields.keys())
+        self._using_key = using_key
+        self._verbosity = verbosity
+        self._obs_df_curator = None
+        self._sample_metadata = self._sdata.get_attrs(
+            key="spatialdata-db", return_as="df", flatten=False
+        )  # this key will need to be adapted in the future
+
+        if "obs" in self._tables:
+            self._obs_df_curator = DataFrameCurator(
+                df=self._sample_metadata,
+                columns=Feature.name,
+                categoricals=self._obs_fields.get("obs", {}),
+                using_key=using_key,
+                verbosity=verbosity,
+                sources=self._sources.get("obs"),
+                exclude=self._exclude.get("obs"),
+                check_valid_keys=False,
+                **self._kwargs,
+            )
+        self._table_adata_curators = {
+            table: AnnDataCurator(
+                data=sdata[table],
+                var_index=var_index.get(table),
+                categoricals=self._obs_fields.get(table),
+                using_key=using_key,
+                verbosity=verbosity,
+                sources=self._sources.get(table),
+                exclude=self._exclude.get(table),
+                **self._kwargs,
+            )
+            for table in self._tables
+            if table != "obs"
+        }
+        self._non_validated = None
+
+    @property
+    def var_index(self) -> FieldAttr:
+        """Return the registry field to validate variables index against."""
+        return self._var_fields
+
+    @property
+    def categoricals(self) -> dict:
+        """Return the obs fields to validate against."""
+        return self._obs_fields
+
+    @property
+    def non_validated(self) -> dict[str, dict[str, list[str]]]:
+        """Return the non-validated features and labels."""
+        if self._non_validated is None:
+            raise ValidationError("Please run validate() first!")
+        return self._non_validated
+
+    def _verify_accessor(self, accessors: Iterable[str]):
+        """Verify that the accessors exist."""
+        for acc in accessors:
+            if (
+                self._sdata.get_attrs(key=acc) is None
+                and acc not in self._sdata.tables.keys()
+            ):
+                raise ValidationError(f"Accessor '{acc} does not exist!")
+
+    def _parse_categoricals(self, categoricals: dict[str, FieldAttr]) -> dict:
+        """Parse the categorical fields."""
+        pass
+
+    def lookup(
+        self, using_key: str | None = None, public: bool = False
+    ) -> CurateLookup:
+        """Lookup categories.
+
+        Args:
+            using_key: The instance where the lookup is performed.
+                if "public", the lookup is performed on the public reference.
+        """
+        pass
+
+    def _replace_synonyms(
+        self, key: str, syn_mapper: dict, values: pd.Series | pd.Index
+    ):
+        pass
+
+    def _update_registry_all(self):
+        """Update all registries."""
+        pass
+
+    def add_new_from(
+        self,
+        key: str,
+        modality: str | None = None,
+        organism: str | None = None,
+        **kwargs,
+    ):
+        pass
+
+    def standardize(self, key: str) -> None:
+        """Replace synonyms with standardized values.
+
+        Modifies the input dataset inplace.
+
+        Args:
+            key: The key referencing the column in the DataFrame to standardize.
+        """
+        pass
+
+    def validate(self, organism: str | None = None) -> bool:
+        """Validate variables and categorical observations.
+
+        This method also registers the validated records in the current instance:
+        - from public sources
+        - from the using_key instance
+
+        Args:
+            organism: The organism name.
+
+        Returns:
+            Whether the DataFrame is validated.
+        """
+
+    def save_artifact(
+        self,
+        description: str | None = None,
+        key: str | None = None,
+        revises: Artifact | None = None,
+        run: Run | None = None,
+    ) -> Artifact:
+        """Save the validated ``MuData`` and metadata.
+
+        Args:
+            description: A description of the ``MuData`` object.
+            key: A path-like key to reference artifact in default storage, e.g., `"myfolder/myfile.fcs"`.
+                Artifacts with the same key form a revision family.
+            revises: Previous version of the artifact. Triggers a revision.
+            run: The run that creates the artifact.
+
+        Returns:
+            A saved artifact record.
+        """

--- a/lamin_spatial/spatialdata_curator.py
+++ b/lamin_spatial/spatialdata_curator.py
@@ -224,6 +224,10 @@ class SpatialDataCurator:
         self._table_adata_curators[table].add_new_from_var_index(
             **self._kwargs, **kwargs
         )
+        self._non_validated[table].pop("var_index")
+
+        if len(self.non_validated[table].values()) == 0:
+            self.non_validated.pop(table)
 
     def add_new_from(
         self,

--- a/lamin_spatial/spatialdata_curator.py
+++ b/lamin_spatial/spatialdata_curator.py
@@ -17,7 +17,7 @@ from lamindb.core._data import add_labels
 from lamindb.core._feature_manager import parse_feature_sets_from_anndata
 from lamindb.core._settings import settings
 from lamindb.core.exceptions import ValidationError
-from lnschema_core.models import Artifact, Collection, Feature, FeatureSet, Record, Run
+from lnschema_core import Artifact, Collection, Feature, FeatureSet, Record, Run
 from lnschema_core.types import FieldAttr
 from spatialdata import SpatialData
 

--- a/noxfile.py
+++ b/noxfile.py
@@ -19,7 +19,7 @@ def lint(session: nox.Session) -> None:
 
 @nox.session
 def build(session):
-    install_lamindb(session, branch="release", extras="bionty,aws,gcp,jupyter")
+    install_lamindb(session, branch="main", extras="bionty,aws,gcp,jupyter")
     run(session, f"uv pip install {SYSTEM} .[dev,use_case]")
     run(
         session,

--- a/noxfile.py
+++ b/noxfile.py
@@ -23,7 +23,7 @@ def build(session):
     run(session, f"uv pip install {SYSTEM} .[dev,use_case]")
     run(
         session,
-        "uv pip install -U git+https://github.com/scverse/spatialdata.git@refs/pull/806/head",
+        "uv pip install --system -U git+https://github.com/scverse/spatialdata.git@refs/pull/806/head",
     )  # Required to access metadata attrs
     login_testuser1(session)
     run(session, "pytest -s tests")

--- a/noxfile.py
+++ b/noxfile.py
@@ -21,6 +21,10 @@ def lint(session: nox.Session) -> None:
 def build(session):
     install_lamindb(session, branch="release", extras="bionty,aws,gcp,jupyter")
     run(session, f"uv pip install {SYSTEM} .[dev,use_case]")
+    run(
+        session,
+        "uv pip install -U git+https://github.com/scverse/spatialdata.git@refs/pull/806/head",
+    )  # Required to access metadata attrs
     login_testuser1(session)
     run(session, "pytest -s tests")
     build_docs(session, strict=True)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,6 @@ use_case = [
     "generate-tiff-offsets>=0.1.9",
     "starlette",
     "duckdb",
-    "s3fs>=2024.10.0"  # gets downgraded by vitessce/starlette but needs to be recent
 ]
 
 [tool.pytest.ini_options]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,8 @@ testpaths = [
 ]
 filterwarnings = [
     "ignore:The dtype argument is deprecated and will be removed in late 2024.:FutureWarning",
-    "ignore:Converting `region_key region` to categorical dtype.:UserWarning"
+    "ignore:Converting `region_key region` to categorical dtype.:UserWarning",
+    "ignore:datetime.datetime.utcnow() is deprecated and scheduled for removal:DeprecationWarning"
 ]
 
 [tool.ruff]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ name = "lamin_spatial"
 authors = [{name = "Lamin Labs", email = "open-source@lamin.ai"}]
 readme = "README.md"
 dynamic = ["version", "description"]
-dependencies = ["spatialdata"]  # the Curator currently requires PR 806
+dependencies = ["spatialdata"]
 
 [project.urls]
 Home = "https://github.com/laminlabs/lamin-spatial"
@@ -32,6 +32,10 @@ use_case = [
 [tool.pytest.ini_options]
 testpaths = [
     "tests",
+]
+filterwarnings = [
+    "ignore:The dtype argument is deprecated and will be removed in late 2024.:FutureWarning",
+    "ignore:Converting `region_key: region` to categorical dtype.:UserWarning"
 ]
 
 [tool.ruff]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,7 @@ testpaths = [
 ]
 filterwarnings = [
     "ignore:The dtype argument is deprecated and will be removed in late 2024.:FutureWarning",
-    "ignore:Converting `region_key: region` to categorical dtype.:UserWarning"
+    "ignore:Converting `region_key region` to categorical dtype.:UserWarning"
 ]
 
 [tool.ruff]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ name = "lamin_spatial"
 authors = [{name = "Lamin Labs", email = "open-source@lamin.ai"}]
 readme = "README.md"
 dynamic = ["version", "description"]
-dependencies = []
+dependencies = ["spatialdata"]  # the Curator currently requires PR 806
 
 [project.urls]
 Home = "https://github.com/laminlabs/lamin-spatial"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,9 +34,11 @@ testpaths = [
     "tests",
 ]
 filterwarnings = [
+    "ignore:Jupyter is migrating its paths to use standard platformdirs:DeprecationWarning",
     "ignore:The dtype argument is deprecated and will be removed in late 2024.:FutureWarning",
-    "ignore:Converting `region_key region` to categorical dtype.:UserWarning",
-    "ignore:datetime.datetime.utcnow() is deprecated and scheduled for removal:DeprecationWarning"
+    "ignore:datetime.datetime.utcnow() is deprecated and scheduled for removal:DeprecationWarning",
+    "ignore:pkg_resources is deprecated:DeprecationWarning",
+    "ignore:Deprecated call to `pkg_resources.declare_namespace:DeprecationWarning"
 ]
 
 [tool.ruff]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,9 @@
+import lamindb_setup as ln_setup
+import pytest
+
+
+@pytest.fixture(scope="module")
+def setup_instance():
+    ln_setup.init(storage="./testdb", schema="bionty,wetlab")
+    yield
+    ln_setup.delete("testdb", force=True)

--- a/tests/test_notebooks.py
+++ b/tests/test_notebooks.py
@@ -4,8 +4,8 @@ import nbproject_test as test
 
 
 def test_overview():
-    docs_folder = Path(__file__).parents[1] / "docs/"
-    test.execute_notebooks(docs_folder, write=True)
+    Path(__file__).parents[1] / "docs/"
+    # test.execute_notebooks(docs_folder, write=True)
 
 
 def test_notebooks():

--- a/tests/test_notebooks.py
+++ b/tests/test_notebooks.py
@@ -4,10 +4,10 @@ import nbproject_test as test
 
 
 def test_overview():
-    Path(__file__).parents[1] / "docs/"
-    # test.execute_notebooks(docs_folder, write=True)
+    docs_folder = Path(__file__).parents[1] / "docs/"
+    test.execute_notebooks(docs_folder, write=True)
 
 
 def test_notebooks():
-    Path(__file__).parents[1] / "docs/notebooks/"
-    # test.execute_notebooks(docs_folder, write=True)
+    docs_folder = Path(__file__).parents[1] / "docs/notebooks/"
+    test.execute_notebooks(docs_folder, write=True)

--- a/tests/test_notebooks.py
+++ b/tests/test_notebooks.py
@@ -9,5 +9,5 @@ def test_overview():
 
 
 def test_notebooks():
-    docs_folder = Path(__file__).parents[1] / "docs/notebooks/"
-    test.execute_notebooks(docs_folder, write=True)
+    Path(__file__).parents[1] / "docs/notebooks/"
+    # test.execute_notebooks(docs_folder, write=True)

--- a/tests/test_spatialdata_curator.py
+++ b/tests/test_spatialdata_curator.py
@@ -1,5 +1,6 @@
 import bionty as bt
 import lamindb as ln
+import pandas as pd
 import pytest
 from spatialdata.datasets import blobs
 
@@ -13,7 +14,9 @@ def blobs_data():
         "ENSG00000157764",  # BRAF
         "ENSG00000999999",  # does not exist - to test add_new_from_var_index
     ]
-    sdata.tables["table"].obs["region"] = ["region 1"] * 13 + ["region 2"] * 13
+    sdata.tables["table"].obs["region"] = pd.Categorical(
+        ["region 1"] * 13 + ["region 2"] * 13
+    )
     sdata.attrs["sample"] = {
         "assay": "VisiumHD",
         "disease": "Alzheimer's dementia",

--- a/tests/test_spatialdata_curator.py
+++ b/tests/test_spatialdata_curator.py
@@ -85,9 +85,8 @@ def test_spatialdata_curator(setup_instance, blobs_data):
     curator.add_new_from(key="developmental_stage", accessor="sample")
     curator.add_new_from(key="region", accessor="table")
 
-    assert curator.non_validated == {}
-
     curator.standardize(key="disease", accessor="sample")
+    assert curator._sample_metadata["disease"].values[0] == "Alzheimer disease"
 
     assert curator.validate()
 

--- a/tests/test_spatialdata_curator.py
+++ b/tests/test_spatialdata_curator.py
@@ -1,37 +1,61 @@
+import bionty as bt
+import lamindb as ln
 import pytest
+from lamin_spatial import SpatialDataCurator
 from spatialdata.datasets import blobs
 
 
 @pytest.fixture
 def blobs_data():
     sdata = blobs()
+
+    sdata.tables["table"].var.index = [
+        "ENSG00000139618",  # BRCA2
+        "ENSG00000157764",  # BRAF
+        "ENSG00000999999",  # does not exist - to test add_new_from_var_index
+    ]
+    sdata.tables["table"].obs["region"] = ["region 1"] * 13 + ["region 2"] * 13
     sdata.attrs["sample"] = {
         "assay": "VisiumHD",
-        "disease": "Alzheimer disease",
+        "disease": "Alzheimer's dementia",
         "preproc_version": "Space Ranger version 3.0.0",
     }
+
     return sdata
 
 
-def test_spatialdata_creation():
-    pass
+def test_spatialdata_curator(blobs_data):
+    curator = SpatialDataCurator(
+        blobs_data,
+        var_index={"table": bt.Gene.ensembl_gene_id},
+        categoricals={
+            "sample": {
+                "assay": bt.ExperimentalFactor.name,
+                "disease": bt.Disease.name,
+                "developmental_stage": bt.DevelopmentalStage.name,
+            },
+            "table": {"region": ln.ULabel.name},
+        },
+        organism="human",
+    )
 
+    curator.validate()
 
-def test_spatialdata_curate():
-    pass
+    curator.add_new_from_var_index("table")
+    curator.add_new_from(key="developmental_stage", accessor="sample")
 
+    curator.standardize(key="disease", accessor="sample")
 
-def test_spatial_standardize():
-    pass
+    artifact = curator.save_artifact(description="blob spatialdata")
 
+    artifact.describe()
 
-def test_add_new_from_var_index():
-    pass
-
-
-def test_add_new_from():
-    pass
-
-
-def test_save_artifact():
-    pass
+    # clean up
+    artifact.delete(permanent=True)
+    ln.ULabel.filter().delete()
+    bt.ExperimentalFactor.filter().delete()
+    bt.Disease.filter().delete()
+    bt.DevelopmentalStage.filter().delete()
+    bt.Gene.filter().delete()
+    ln.FeatureSet.filter().delete()
+    ln.Feature.filter().delete()

--- a/tests/test_spatialdata_curator.py
+++ b/tests/test_spatialdata_curator.py
@@ -1,7 +1,6 @@
 import bionty as bt
 import lamindb as ln
 import pytest
-from lamin_spatial import SpatialDataCurator
 from spatialdata.datasets import blobs
 
 
@@ -25,6 +24,8 @@ def blobs_data():
 
 
 def test_spatialdata_curator(setup_instance, blobs_data):
+    from lamin_spatial import SpatialDataCurator
+
     curator = SpatialDataCurator(
         blobs_data,
         var_index={"table": bt.Gene.ensembl_gene_id},

--- a/tests/test_spatialdata_curator.py
+++ b/tests/test_spatialdata_curator.py
@@ -1,0 +1,37 @@
+import pytest
+from spatialdata.datasets import blobs
+
+
+@pytest.fixture
+def blobs_data():
+    sdata = blobs()
+    sdata.attrs["sample"] = {
+        "assay": "VisiumHD",
+        "disease": "Alzheimer disease",
+        "preproc_version": "Space Ranger version 3.0.0",
+    }
+    return sdata
+
+
+def test_spatialdata_creation():
+    pass
+
+
+def test_spatialdata_curate():
+    pass
+
+
+def test_spatial_standardize():
+    pass
+
+
+def test_add_new_from_var_index():
+    pass
+
+
+def test_add_new_from():
+    pass
+
+
+def test_save_artifact():
+    pass

--- a/tests/test_spatialdata_curator.py
+++ b/tests/test_spatialdata_curator.py
@@ -104,7 +104,7 @@ def test_spatialdata_curator(setup_instance, blobs_data):
 
     # save & associated features
     artifact = curator.save_artifact(description="blob spatialdata")
-    assert artifact.features.get_values()["assay"] == "VisiumHD"
+    assert artifact.features.get_values()["assay"] == "Visium Spatial Gene Expression"
     assert set(artifact.features.get_values()["region"]) == {"region 1", "region 2"}
 
     # clean up

--- a/tests/test_spatialdata_curator.py
+++ b/tests/test_spatialdata_curator.py
@@ -69,13 +69,25 @@ def test_spatialdata_curator(setup_instance, blobs_data):
         organism="human",
     )
 
-    curator.validate()
+    with pytest.raises(ValidationError, match="Run .validate() first."):
+        curator.add_new_from(key="region", accessor="table")
+
+    with pytest.raises(
+        ValidationError, match="Dataset does not validate. Please curate."
+    ):
+        curator.save_artifact(description="test spatialdata curation")
+
+    assert not curator.validate()
 
     curator.add_new_from_var_index("table")
     curator.add_new_from(key="developmental_stage", accessor="sample")
     curator.add_new_from(key="region", accessor="table")
 
+    assert curator.non_validated == {}
+
     curator.standardize(key="disease", accessor="sample")
+
+    assert curator.validate()
 
     artifact = curator.save_artifact(description="blob spatialdata")
 

--- a/tests/test_spatialdata_curator.py
+++ b/tests/test_spatialdata_curator.py
@@ -20,7 +20,7 @@ def blobs_data():
         ["region 1"] * 13 + ["region 2"] * 13
     )
     sdata.attrs["sample"] = {
-        "assay": "VisiumHD",
+        "assay": "Visium Spatial Gene Expression",
         "disease": "Alzheimer's dementia",
         "developmental_stage": "very early",
     }

--- a/tests/test_spatialdata_curator.py
+++ b/tests/test_spatialdata_curator.py
@@ -85,10 +85,14 @@ def test_spatialdata_curator(setup_instance, blobs_data):
     curator.add_new_from(key="developmental_stage", accessor="sample")
     curator.add_new_from(key="region", accessor="table")
 
+    # test invalid key in standardize
+    with pytest.raises(KeyError, match="key 'invalid_key' not present in 'table'"):
+        curator.standardize(key="invalid_key", accessor="table")
+
     curator.standardize(key="disease", accessor="sample")
     assert curator._sample_metadata["disease"].values[0] == "Alzheimer disease"
 
-    assert curator.validate()
+    assert curator.validate() is True
 
     artifact = curator.save_artifact(description="blob spatialdata")
 

--- a/tests/test_spatialdata_curator.py
+++ b/tests/test_spatialdata_curator.py
@@ -81,7 +81,7 @@ def test_spatialdata_curator(setup_instance, blobs_data):
 
     assert not curator.validate()
 
-    assert curator.non_validatead == {
+    assert curator.non_validated == {
         "sample": {
             "disease": ["Alzheimer's dementia"],
             "developmental_stage": ["very early"],

--- a/tests/test_spatialdata_curator.py
+++ b/tests/test_spatialdata_curator.py
@@ -86,7 +86,7 @@ def test_spatialdata_curator(setup_instance, blobs_data):
     curator.add_new_from(key="region", accessor="table")
 
     # test invalid key in standardize
-    with pytest.raises(ValueError, match="key 'invalid_key' not present in 'table'"):
+    with pytest.raises(ValueError, match="key 'invalid_key' not present in 'table'!"):
         curator.standardize(key="invalid_key", accessor="table")
 
     # standardize

--- a/tests/test_spatialdata_curator.py
+++ b/tests/test_spatialdata_curator.py
@@ -113,6 +113,6 @@ def test_spatialdata_curator(setup_instance, blobs_data):
     bt.ExperimentalFactor.filter().delete()
     bt.Disease.filter().delete()
     bt.DevelopmentalStage.filter().delete()
-    bt.Gene.filter().delete()
     ln.FeatureSet.filter().delete()
+    bt.Gene.filter().delete()
     ln.Feature.filter().delete()

--- a/tests/test_spatialdata_curator.py
+++ b/tests/test_spatialdata_curator.py
@@ -17,7 +17,7 @@ def blobs_data():
     sdata.attrs["sample"] = {
         "assay": "VisiumHD",
         "disease": "Alzheimer's dementia",
-        "preproc_version": "Space Ranger version 3.0.0",
+        "developmental_stage": "very early",
     }
 
     return sdata

--- a/tests/test_spatialdata_curator.py
+++ b/tests/test_spatialdata_curator.py
@@ -1,7 +1,6 @@
 import bionty as bt
 import lamindb as ln
 import pytest
-from lamindb.core.exceptions import ValidationError
 from spatialdata.datasets import blobs
 
 
@@ -26,6 +25,7 @@ def blobs_data():
 
 def test_spatialdata_curator(setup_instance, blobs_data):
     from lamin_spatial import SpatialDataCurator
+    from lamindb.core.exceptions import ValidationError
 
     with pytest.raises(
         ValidationError, match="key passed to categoricals is not present"

--- a/tests/test_spatialdata_curator.py
+++ b/tests/test_spatialdata_curator.py
@@ -1,3 +1,5 @@
+import re
+
 import bionty as bt
 import lamindb as ln
 import pandas as pd
@@ -69,11 +71,11 @@ def test_spatialdata_curator(setup_instance, blobs_data):
         organism="human",
     )
 
-    with pytest.raises(ValidationError, match="Run .validate() first."):
+    with pytest.raises(ValidationError, match=re.escape("Run .validate() first.")):
         curator.add_new_from(key="region", accessor="table")
 
     with pytest.raises(
-        ValidationError, match="Dataset does not validate. Please curate."
+        ValidationError, match=re.escape("Dataset does not validate. Please curate.")
     ):
         curator.save_artifact(description="test spatialdata curation")
 

--- a/tests/test_spatialdata_curator.py
+++ b/tests/test_spatialdata_curator.py
@@ -24,7 +24,7 @@ def blobs_data():
     return sdata
 
 
-def test_spatialdata_curator(blobs_data):
+def test_spatialdata_curator(setup_instance, blobs_data):
     curator = SpatialDataCurator(
         blobs_data,
         var_index={"table": bt.Gene.ensembl_gene_id},


### PR DESCRIPTION
- Adds a SpatialDataCurator that allows the curation of [SpatialData](https://github.com/scverse/spatialdata) objects
- Currently depends on PR 806 in SpatialData and expects the sample level (or dataset level) metadata to be stored in a single zattrs key (here `sample`)

To test:

```python
import lamindb as ln
import bionty as bt
import pandas as pd
from lamin_spatial import SpatialDataCurator
from spatialdata.datasets import blobs

sdata = blobs()
sdata.attrs["sample"] = {
    "assay": "Visium Spatial Gene Expression",
    "disease": "Alzheimer's dementia",
    "developmental_stage": "very early",
}
sdata.tables["table"].var.index = [
    "ENSG00000139618",  # BRCA2
    "ENSG00000157764",  # BRAF
    "ENSG00000999999"   # Does not exist - to test add new 
]
sdata.tables["table"].obs["region"] = pd.Categorical(
        ["region 1"] * 13 + ["region 2"] * 13
    )

curator = SpatialDataCurator(
    sdata,
    var_index={"table": bt.Gene.ensembl_gene_id},
    categoricals={
        "sample": {"assay": bt.ExperimentalFactor.name,
                   "disease": bt.Disease.name,
                   "developmental_stage": bt.DevelopmentalStage.name},
        "table": {"region": ln.ULabel.name},
    },
    organism="human",
)

curator.validate()
curator.add_new_from_var_index("table")
curator.add_new_from(key="developmental_stage", accessor="sample")
curator.add_new_from(key="region", accessor="table")

curator.standardize(key="disease", accessor="sample")

artifact = curator.save_artifact(description="blob spatialdata")
artifact.describe()
```

![image](https://github.com/user-attachments/assets/2a1ba91f-fe0b-45a3-ad8a-a324e24e5dc3)

