### PR TITLE
📝  Hide output in vitessce guide

### DIFF
--- a/docs/vitessce.ipynb
+++ b/docs/vitessce.ipynb
@@ -134,7 +134,9 @@
     "slideshow": {
      "slide_type": ""
     },
-    "tags": []
+    "tags": [
+        "hide-output"
+    ]
    },
    "outputs": [],
    "source": [


### PR DESCRIPTION
Hides this output:
<img width="796" height="220" alt="Bildschirmfoto 2025-09-17 um 22 31 12" src="https://github.com/user-attachments/assets/de440d12-c9bc-4819-b72f-99662d62a416" />
