### PR TITLE
💚 Fix CI

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -19,9 +19,9 @@ def lint(session: nox.Session) -> None:
 
 @nox.session
 def build(session):
-    # do not use zarr extra here otherwise spatialdata won't be installed
     install_lamindb(session, branch="main", extras="bionty,gcp,jupyter,zarr")
     run(session, f"uv pip install {SYSTEM} .[dev,use_case]")
+    # vitessce requires zarr<3, and therefore upper limits spatialdata<0.5.0
     run(session, f"uv pip install {SYSTEM} spatialdata<=0.5.0")
     login_testuser1(session)
     run(session, "pytest -s tests")


### PR DESCRIPTION
Vitessce requires zarr<3, the most recent spatialdata requires zarr 3, so we upper bound spatialdata in CI.